### PR TITLE
Fix tests that were hardcoded to use BitBucket as a source of data

### DIFF
--- a/src/test/java/eu/cessda/cmv/core/CessdaMetadataValidatorFactoryTest.java
+++ b/src/test/java/eu/cessda/cmv/core/CessdaMetadataValidatorFactoryTest.java
@@ -26,9 +26,9 @@ import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 
 import static org.gesis.commons.resource.Resource.newResource;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -45,21 +45,21 @@ class CessdaMetadataValidatorFactoryTest
 	}
 
 	@Test
-	void newDomDocument()
+	void newDomDocument() throws IOException
 	{
-		File file = new File( "src/main/resources/cmv-profile-ddi-v32.xml" );
-		DomDocument.V11 document = factory.newDomDocument( file );
+		URL resourceUrl = this.getClass().getResource( "/cmv-profile-ddi-v32.xml" );
+		assert resourceUrl != null;
+		DomDocument.V11 document = factory.newDomDocument( resourceUrl.openStream() );
 		assertThat( document.selectNode( "/pr:DDIProfile" ), notNullValue() );
 	}
 
 	@ParameterizedTest
-	@ValueSource(
-			strings = {
-					"https://bitbucket.org/cessda/cessda.cmv.core/raw/815a9aa0688300aea56b7ff31bdb99ec9714729d/src/main/resources/demo-documents/ddi-v25/fsd-3307.xml",
-					"https://bitbucket.org/cessda/cessda.cmv.core/raw/815a9aa0688300aea56b7ff31bdb99ec9714729d/src/main/resources/demo-documents/ddi-v25/fsd-3307-oaipmh.xml" } )
+	@ValueSource( strings = { "/demo-documents/ddi-v25/fsd-3307.xml", "/demo-documents/ddi-v25/fsd-3307-oaipmh.xml" } )
 	void newDocument( String uri )
 	{
-		Resource resource = newResource( uri );
+		URL resourceUrl = this.getClass().getResource( uri );
+		assert resourceUrl != null;
+		Resource resource = newResource( resourceUrl );
 		assertThat( factory.newDocument( resource ), notNullValue() );
 	}
 
@@ -67,7 +67,9 @@ class CessdaMetadataValidatorFactoryTest
 	void newDocumentWithNotWellformedDocument() throws IOException
 	{
 		// given
-		Resource resource = newResource( getClass().getResource( "/demo-documents/ddi-v25/ukds-7481-not-wellformed.xml-invalid" ) );
+		URL resourceUrl = getClass().getResource( "/demo-documents/ddi-v25/ukds-7481-not-wellformed.xml-invalid" );
+		assert resourceUrl != null;
+		Resource resource = newResource( resourceUrl );
 		try ( InputStream inputStream = resource.readInputStream() )
 		{
 			// when

--- a/src/test/java/eu/cessda/cmv/core/mediatype/validationrequest/v0/ValidationRequestV0Test.java
+++ b/src/test/java/eu/cessda/cmv/core/mediatype/validationrequest/v0/ValidationRequestV0Test.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.net.URL;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.LOWER_CAMEL_CASE;
 import static com.fasterxml.jackson.databind.PropertyNamingStrategies.UPPER_CAMEL_CASE;
@@ -54,9 +55,16 @@ class ValidationRequestV0Test
 
 	ValidationRequestV0Test()
 	{
-		String baseUrl = "https://bitbucket.org/cessda/cessda.cmv.core/raw/1a01a5e7ede385699e169a56ab9e700de716778a/src/main/resources/demo-documents/ddi-v25";
-		profile = new TextResource( newResource( baseUrl + "/cdc25_profile.xml" ) );
-		document = new TextResource( newResource( baseUrl + "/gesis-5300.xml" ) );
+		String baseUrl = "/demo-documents/ddi-v25";
+
+		URL profileResource = this.getClass().getResource( baseUrl + "/cdc25_profile.xml" );
+		URL documentResource = this.getClass().getResource( baseUrl + "/gesis-5300.xml" );
+
+		assert profileResource != null;
+		assert documentResource != null;
+
+		profile = new TextResource( newResource( profileResource ) );
+		document = new TextResource( newResource( documentResource ) );
 		validationGateName = ValidationGateName.BASIC;
 		testEnv = DefaultTestEnv.newInstance( ValidationRequestV0Test.class );
 	}


### PR DESCRIPTION
These tests referenced data stored in the BitBucket blob store, and as a result broke when the repository was migrated to GitHub. This PR modifies the tests to load the resources directly in the checked out repository.