### PR TITLE
Add an API to allow users to define custom validation gates 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
 				<artifactId>maven-release-plugin</artifactId>
 				<version>2.5.3</version>
 				<configuration>
-					<tagNameFormat>v@{project.version}</tagNameFormat>
+					<tagNameFormat>@{project.version}</tagNameFormat>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/eu/cessda/cmv/core/AbstractValidationGate.java
+++ b/src/main/java/eu/cessda/cmv/core/AbstractValidationGate.java
@@ -34,9 +34,9 @@ abstract class AbstractValidationGate implements ValidationGate.V10
 		constraintTypes = new ArrayList<>();
 	}
 
-	protected void addConstraintType( Class<? extends Constraint.V20> constraint )
+	AbstractValidationGate( Collection<Class<? extends Constraint.V20>> constraints )
 	{
-		constraintTypes.add( constraint );
+		this.constraintTypes = new ArrayList<>( constraints );
 	}
 
 	protected void addConstraintType( Collection<Class<? extends Constraint.V20>> constraints )
@@ -64,4 +64,5 @@ abstract class AbstractValidationGate implements ValidationGate.V10
 		}
 		return (List<T>) constraintViolations;
 	}
+
 }

--- a/src/main/java/eu/cessda/cmv/core/CessdaMetadataValidatorFactory.java
+++ b/src/main/java/eu/cessda/cmv/core/CessdaMetadataValidatorFactory.java
@@ -74,6 +74,11 @@ public class CessdaMetadataValidatorFactory
 		return newDomDocument( newResource( uri ).readInputStream() );
 	}
 
+	public DomDocument.V11 newDomDocument( URL url ) throws IOException
+	{
+		return newDomDocument( url.openStream() );
+	}
+
 	public DomDocument.V11 newDomDocument( InputStream inputStream )
 	{
 		return XercesXalanDocument.newBuilder()

--- a/src/main/java/eu/cessda/cmv/core/CessdaMetadataValidatorFactory.java
+++ b/src/main/java/eu/cessda/cmv/core/CessdaMetadataValidatorFactory.java
@@ -101,19 +101,19 @@ public class CessdaMetadataValidatorFactory
 			else if ( OaipmhV20Detector.MEDIATYPE.equals( mediaType ) )
 			{
 				String xpath = "/OAI-PMH/GetRecord/record/metadata/*[1]";
-				Optional<InputStream> extractedElementInputstream = xmlElementExtractor.extractAsInputStream( bufferedInputStream, xpath );
-				if ( extractedElementInputstream.isPresent() )
+				Optional<InputStream> extractedElementInputStream = xmlElementExtractor.extractAsInputStream( bufferedInputStream, xpath );
+				if ( extractedElementInputStream.isPresent() )
 				{
-					return newDocument( extractedElementInputstream.get() );
+					return newDocument( extractedElementInputStream.get() );
 				}
 			}
 			throw new NotDocumentException( String.format( "Detected media type: %s", mediaType ) );
 		}
-		catch (XmlNotWellformedException e)
+		catch ( XmlNotWellformedException e )
 		{
 			throw new NotDocumentException( String.format( "Not well-formed XML: %s", e.getMessage() ) );
 		}
-		catch (Exception e)
+		catch ( IOException e )
 		{
 			throw new NotDocumentException( e );
 		}

--- a/src/main/java/eu/cessda/cmv/core/CessdaMetadataValidatorFactory.java
+++ b/src/main/java/eu/cessda/cmv/core/CessdaMetadataValidatorFactory.java
@@ -34,13 +34,27 @@ import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
-import java.util.Optional;
+import java.util.*;
 
 import static java.util.Objects.requireNonNull;
 import static org.gesis.commons.resource.Resource.newResource;
 
 public class CessdaMetadataValidatorFactory
 {
+	private static final Set<String> CONSTRAINTS = Collections.unmodifiableSet( new HashSet<>( Arrays.asList(
+			"CompilableXPathConstraint",
+			"ControlledVocabularyRepositoryConstraint",
+			"FixedValueNodeConstraint",
+			"MandatoryNodeConstraint",
+			"MandatoryNodeIfParentPresentConstraint",
+			"MaximumElementOccuranceConstraint",
+			"NodeInProfileConstraint",
+			"NotBlankNodeConstraint",
+			"OptionalNodeConstraint",
+			"PredicatelessXPathConstraint",
+			"RecommendedNodeConstraint"
+	) ) );
+
 	private final XmlElementExtractor.V10 xmlElementExtractor;
 	private final Tika documentMediaTypeDetector;
 
@@ -89,34 +103,13 @@ public class CessdaMetadataValidatorFactory
 		return newDocument( requireNonNull( resource ).readInputStream() );
 	}
 
-	public Document.V11 newDocument( InputStream inputStream )
+	/**
+	 * Returns a validation gate with the given name.
+	 */
+	public static ValidationGate.V10 getValidationGate( ValidationGateName name )
 	{
-		try ( InputStream bufferedInputStream = new BufferedInputStream( requireNonNull( inputStream ) ) )
-		{
-			String mediaType = documentMediaTypeDetector.detect( bufferedInputStream );
-			if ( DdiDetector.MEDIATYPE.equals( mediaType ) )
-			{
-				return new DomCodebookDocument( bufferedInputStream );
-			}
-			else if ( OaipmhV20Detector.MEDIATYPE.equals( mediaType ) )
-			{
-				String xpath = "/OAI-PMH/GetRecord/record/metadata/*[1]";
-				Optional<InputStream> extractedElementInputStream = xmlElementExtractor.extractAsInputStream( bufferedInputStream, xpath );
-				if ( extractedElementInputStream.isPresent() )
-				{
-					return newDocument( extractedElementInputStream.get() );
-				}
-			}
-			throw new NotDocumentException( String.format( "Detected media type: %s", mediaType ) );
-		}
-		catch ( XmlNotWellformedException e )
-		{
-			throw new NotDocumentException( String.format( "Not well-formed XML: %s", e.getMessage() ) );
-		}
-		catch ( IOException e )
-		{
-			throw new NotDocumentException( e );
-		}
+		requireNonNull( name, "name must not be null" );
+		return name.getValidationGate();
 	}
 
 	public Profile.V10 newProfile( Resource resource )
@@ -163,22 +156,111 @@ public class CessdaMetadataValidatorFactory
 		return newDdiInputStream( newResource( url ).readInputStream() );
 	}
 
+	/**
+	 * Returns a validation gate for the given constraints. The constraints are passed as the short name
+	 * of the class (i.e. FixedValueNodeConstraint).
+	 *
+	 * @param constraints the constraints to be added
+	 * @return the validation gate
+	 * @throws InvalidGateException if any of the given constraints are invalid
+	 */
+	public static ValidationGate.V10 newValidationGate( Collection<String> constraints ) throws InvalidGateException
+	{
+		ArrayList<InvalidConstraintException> exceptions = new ArrayList<>();
+
+		// Attempt to map the names of constraints to class objects
+		List<Class<? extends Constraint.V20>> list = new ArrayList<>();
+		for ( String c : constraints )
+		{
+			try
+			{
+				// Construct the fully qualified class name for the constraints
+				Class<?> potentialConstraint = Class.forName( "eu.cessda.cmv.core." + c );
+				list.add( potentialConstraint.asSubclass( Constraint.V20.class ) );
+			}
+			catch ( ClassNotFoundException | ClassCastException e )
+			{
+				exceptions.add( new InvalidConstraintException( c, e ) );
+			}
+		}
+
+
+		if ( exceptions.isEmpty() )
+		{
+			// All constraints successfully added
+			return new AbstractValidationGate( list )
+			{
+			};
+		}
+		else
+		{
+			throw new InvalidGateException( exceptions );
+		}
+	}
+
+	/**
+	 * Return a set of all known constraints.
+	 * <p>
+	 * This should be used with {@link CessdaMetadataValidatorFactory#newValidationGate(Collection)}
+	 * to ensure that a validation gate is not constructed with invalid constraints.
+	 */
+	public static Set<String> getConstraints()
+	{
+		return CONSTRAINTS;
+	}
+
+	@SuppressWarnings( "java:S1133" ) // false positive - XPath detected as a URI
+	public Document.V11 newDocument( InputStream inputStream )
+	{
+		try ( InputStream bufferedInputStream = new BufferedInputStream( requireNonNull( inputStream ) ) )
+		{
+			String mediaType = documentMediaTypeDetector.detect( bufferedInputStream );
+			if ( DdiDetector.MEDIATYPE.equals( mediaType ) )
+			{
+				return new DomCodebookDocument( bufferedInputStream );
+			}
+			else if ( OaipmhV20Detector.MEDIATYPE.equals( mediaType ) )
+			{
+				String xpath = "/OAI-PMH/GetRecord/record/metadata/*[1]";
+				Optional<InputStream> extractedElementInputStream = xmlElementExtractor.extractAsInputStream( bufferedInputStream, xpath );
+				if ( extractedElementInputStream.isPresent() )
+				{
+					return newDocument( extractedElementInputStream.get() );
+				}
+			}
+			throw new NotDocumentException( String.format( "Detected media type: %s", mediaType ) );
+		}
+		catch ( XmlNotWellformedException e )
+		{
+			throw new NotDocumentException( String.format( "Not well-formed XML: %s", e.getMessage() ) );
+		}
+		catch ( IOException e )
+		{
+			throw new NotDocumentException( e );
+		}
+	}
+
 	public DdiInputStream newDdiInputStream( InputStream inputStream )
 	{
 		try
 		{
 			return new DdiInputStream( inputStream );
 		}
-		catch (IOException e)
+		catch ( IOException e )
 		{
 			throw new IllegalArgumentException( e );
 		}
 	}
 
+	/**
+	 * Returns a validation gate with the given name.
+	 *
+	 * @deprecated use the static method instead
+	 */
+	@Deprecated
 	public ValidationGate.V10 newValidationGate( ValidationGateName name )
 	{
-		requireNonNull( name, "name must not be null" );
-		return name.getValidationGate();
+		return getValidationGate( name );
 	}
 
 	public ValidationService.V10 newValidationService()

--- a/src/main/java/eu/cessda/cmv/core/InvalidConstraintException.java
+++ b/src/main/java/eu/cessda/cmv/core/InvalidConstraintException.java
@@ -1,0 +1,30 @@
+package eu.cessda.cmv.core;
+
+/**
+ * Represents errors that occur when attempting to look up a constraint.
+ */
+public class InvalidConstraintException extends Exception
+{
+	private static final long serialVersionUID = 4324993248911039451L;
+	private final String constraintName;
+
+	/**
+	 * Construct a new instance of {@link InvalidConstraintException} with the specified constraint name and cause.
+	 *
+	 * @param constraintName the name of the constraint that was looked up.
+	 * @param cause          the cause of the lookup failure.
+	 */
+	InvalidConstraintException( String constraintName, Throwable cause )
+	{
+		super( String.format( "%s is not a valid constraint", constraintName ), cause );
+		this.constraintName = constraintName;
+	}
+
+	/**
+	 * Get the name of the constraint that was looked up.
+	 */
+	public String getConstraintName()
+	{
+		return constraintName;
+	}
+}

--- a/src/main/java/eu/cessda/cmv/core/InvalidConstraintException.java
+++ b/src/main/java/eu/cessda/cmv/core/InvalidConstraintException.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * cmv-core
+ * %%
+ * Copyright (C) 2020 - 2023 CESSDA ERIC
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package eu.cessda.cmv.core;
 
 /**

--- a/src/main/java/eu/cessda/cmv/core/InvalidGateException.java
+++ b/src/main/java/eu/cessda/cmv/core/InvalidGateException.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * cmv-core
+ * %%
+ * Copyright (C) 2020 - 2023 CESSDA ERIC
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package eu.cessda.cmv.core;
 
 import java.util.List;

--- a/src/main/java/eu/cessda/cmv/core/InvalidGateException.java
+++ b/src/main/java/eu/cessda/cmv/core/InvalidGateException.java
@@ -1,0 +1,23 @@
+package eu.cessda.cmv.core;
+
+import java.util.List;
+
+/**
+ * Represents errors that occur when constructing a validation gate.
+ */
+public class InvalidGateException extends Exception
+{
+	private static final long serialVersionUID = -4231671316452274178L;
+
+	/**
+	 * Construct a new instance of {@link InvalidGateException} with the given causes. These causes will be treated
+	 * as suppressed exceptions.
+	 *
+	 * @param causes the causes.
+	 */
+	InvalidGateException( List<InvalidConstraintException> causes )
+	{
+		super( String.format( "Gate construction failed: %s", causes.toString() ) );
+		causes.forEach( this::addSuppressed );
+	}
+}

--- a/src/main/java/eu/cessda/cmv/core/ValidationGate.java
+++ b/src/main/java/eu/cessda/cmv/core/ValidationGate.java
@@ -19,8 +19,6 @@
  */
 package eu.cessda.cmv.core;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 public interface ValidationGate
@@ -28,47 +26,5 @@ public interface ValidationGate
 	interface V10 extends ValidationGate
 	{
 		<T extends ConstraintViolation> List<T> validate( Document document, Profile profile );
-
-		/**
-		 * Creates a validation gate for the given constraints. The constraints are passed as the short name
-		 * of the class (i.e. FixedValueNodeConstraint)
-		 *
-		 * @param constraints the constraints to be added
-		 * @return the validation gate
-		 * @throws InvalidGateException if any of the given constraints are invalid
-		 */
-		static ValidationGate.V10 newValidationGate( Collection<String> constraints ) throws InvalidGateException
-		{
-			ArrayList<InvalidConstraintException> exceptions = new ArrayList<>();
-
-			// Attempt to map the names of constraints to class objects
-			List<Class<? extends Constraint.V20>> list = new ArrayList<>();
-			for ( String c : constraints )
-			{
-				try
-				{
-					// Construct the fully qualified class name for the constraints
-					Class<?> potentialConstraint = Class.forName( "eu.cessda.cmv.core." + c );
-					list.add( potentialConstraint.asSubclass( Constraint.V20.class ) );
-				}
-				catch ( ClassNotFoundException | ClassCastException e )
-				{
-					exceptions.add( new InvalidConstraintException( c, e ) );
-				}
-			}
-
-
-			if ( exceptions.isEmpty() )
-			{
-				// All constraints successfully added
-				return new AbstractValidationGate( list )
-				{
-				};
-			}
-			else
-			{
-				throw new InvalidGateException( exceptions );
-			}
-		}
 	}
 }

--- a/src/main/java/eu/cessda/cmv/core/ValidationService.java
+++ b/src/main/java/eu/cessda/cmv/core/ValidationService.java
@@ -19,6 +19,7 @@
  */
 package eu.cessda.cmv.core;
 
+import eu.cessda.cmv.core.mediatype.validationreport.v0.ValidationReportV0;
 import org.gesis.commons.resource.Resource;
 
 import java.net.URI;
@@ -36,5 +37,15 @@ public interface ValidationService
 				Resource document,
 				Resource profile,
 				ValidationGateName validationGateName );
+
+		ValidationReportV0 validate(
+				URI documentUri,
+				URI profileUri,
+				ValidationGate.V10 validationGate );
+
+		ValidationReportV0 validate(
+				Resource documentResource,
+				Resource profileResource,
+				ValidationGate.V10 validationGate );
 	}
 }

--- a/src/main/java/eu/cessda/cmv/core/ValidationServiceV0.java
+++ b/src/main/java/eu/cessda/cmv/core/ValidationServiceV0.java
@@ -70,14 +70,27 @@ class ValidationServiceV0 implements ValidationService.V10
 				validationGateName );
 	}
 
-	private ValidationReportV0 validate(
+	private static ValidationReportV0 validate( Document document, Profile profile, URI documentUri, URI profileUri, ValidationGate.V10 validationGate )
+	{
+		ValidationReportV0 validationReport = validate( document, documentUri, profile, validationGate );
+		LOGGER.info( "Validation executed: CUSTOM, {}, {}", documentUri, profileUri );
+		return validationReport;
+	}
+
+	private static ValidationReportV0 validate(
 			Document document,
 			URI documentUri,
 			Profile profile,
 			URI profileUri,
 			ValidationGateName validationGateName )
 	{
-		ValidationGate.V10 validationGate = factory.newValidationGate( validationGateName );
+		ValidationReportV0 validationReport = validate( document, documentUri, profile, validationGateName.getValidationGate() );
+		LOGGER.info( "Validation executed: {}, {}, {}", validationGateName, documentUri, profileUri );
+		return validationReport;
+	}
+
+	private static ValidationReportV0 validate( Document document, URI documentUri, Profile profile, ValidationGate.V10 validationGate )
+	{
 		List<ConstraintViolation> constraintViolations = validationGate.validate( document, profile );
 
 		ValidationReportV0 validationReport = new ValidationReportV0();
@@ -85,7 +98,37 @@ class ValidationServiceV0 implements ValidationService.V10
 		validationReport.setConstraintViolations( constraintViolations.stream()
 				.map( ConstraintViolationV0::new )
 				.collect( Collectors.toList() ) );
-		LOGGER.info( "Validation executed: {}, {}, {}", validationGateName, documentUri, profileUri );
+
 		return validationReport;
+	}
+
+	@Override
+	public ValidationReportV0 validate(
+			URI documentUri,
+			URI profileUri,
+			ValidationGate.V10 validationGate )
+	{
+		Document document = factory.newDocument( documentUri );
+		Profile profile = factory.newProfile( profileUri );
+		return ValidationServiceV0.validate( document,
+				profile,
+				documentUri,
+				profileUri,
+				validationGate );
+	}
+
+	@Override
+	public ValidationReportV0 validate(
+			Resource documentResource,
+			Resource profileResource,
+			ValidationGate.V10 validationGate )
+	{
+		Document document = factory.newDocument( documentResource );
+		Profile profile = factory.newProfile( profileResource );
+		return ValidationServiceV0.validate( document,
+				profile,
+				documentResource.getUri(),
+				profileResource.getUri(),
+				validationGate );
 	}
 }

--- a/src/main/java/eu/cessda/cmv/core/controlledvocabulary/CessdaControlledVocabularyRepository.java
+++ b/src/main/java/eu/cessda/cmv/core/controlledvocabulary/CessdaControlledVocabularyRepository.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,24 +19,22 @@
  */
 package eu.cessda.cmv.core.controlledvocabulary;
 
-import static java.util.Objects.requireNonNull;
-import static org.gesis.commons.resource.Resource.newResource;
-
-import java.net.URI;
-import java.util.List;
-import java.util.stream.Collectors;
-
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
 import org.gesis.commons.resource.Resource;
 import org.gesis.commons.resource.TextResource;
 
-import com.jayway.jsonpath.Configuration;
-import com.jayway.jsonpath.JsonPath;
+import java.net.URI;
+import java.util.HashSet;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
 
 public class CessdaControlledVocabularyRepository extends AbstractControlledVocabularyRepository
 {
 	public CessdaControlledVocabularyRepository( URI uri )
 	{
-		this( (Resource) newResource( requireNonNull( uri ) ) );
+		this( Resource.<Resource>newResource( requireNonNull( uri ) ) );
 	}
 
 	public CessdaControlledVocabularyRepository( Resource resource )
@@ -46,8 +44,8 @@ public class CessdaControlledVocabularyRepository extends AbstractControlledVoca
 		Object document = Configuration.defaultConfiguration().jsonProvider()
 				.parse( new TextResource( resource ).toString() );
 		List<String> list = JsonPath.read( document, "$.conceptAsMap.*.notation" );
-		setCodeValues( list.stream().collect( Collectors.toSet() ) );
+		setCodeValues( new HashSet<>( list ) );
 		list = JsonPath.read( document, "$.conceptAsMap.*.title" );
-		setDescriptiveTerms( list.stream().collect( Collectors.toSet() ) );
+		setDescriptiveTerms( new HashSet<>( list ) );
 	}
 }

--- a/src/test/java/eu/cessda/cmv/core/CessdaMetadataValidatorFactoryTest.java
+++ b/src/test/java/eu/cessda/cmv/core/CessdaMetadataValidatorFactoryTest.java
@@ -49,7 +49,7 @@ class CessdaMetadataValidatorFactoryTest
 	{
 		URL resourceUrl = this.getClass().getResource( "/cmv-profile-ddi-v32.xml" );
 		assert resourceUrl != null;
-		DomDocument.V11 document = factory.newDomDocument( resourceUrl.openStream() );
+		DomDocument.V11 document = factory.newDomDocument( resourceUrl );
 		assertThat( document.selectNode( "/pr:DDIProfile" ), notNullValue() );
 	}
 

--- a/src/test/java/eu/cessda/cmv/core/CustomConstraintTest.java
+++ b/src/test/java/eu/cessda/cmv/core/CustomConstraintTest.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * cmv-core
+ * %%
+ * Copyright (C) 2020 - 2023 CESSDA ERIC
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package eu.cessda.cmv.core;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/eu/cessda/cmv/core/CustomConstraintTest.java
+++ b/src/test/java/eu/cessda/cmv/core/CustomConstraintTest.java
@@ -4,10 +4,12 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CustomConstraintTest
@@ -61,5 +63,15 @@ class CustomConstraintTest
 						.collect( Collectors.toList() ),
 				hasItems( instanceOf( ClassNotFoundException.class ), instanceOf( ClassCastException.class ) )
 		);
+	}
+
+	@Test
+	void checkThatAllConstraintsAreValid()
+	{
+		// Get all valid constraints
+		Set<String> constrains = CessdaMetadataValidatorFactory.getConstraints();
+
+		// This should not throw as the set of constraints should all be valid
+		assertDoesNotThrow( () -> CessdaMetadataValidatorFactory.newValidationGate( constrains ) );
 	}
 }

--- a/src/test/java/eu/cessda/cmv/core/CustomConstraintTest.java
+++ b/src/test/java/eu/cessda/cmv/core/CustomConstraintTest.java
@@ -1,0 +1,64 @@
+package eu.cessda.cmv.core;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class CustomConstraintTest
+{
+	private final CessdaMetadataValidatorFactory factory = new CessdaMetadataValidatorFactory();
+
+	@Test
+	void shouldCreateValidationGateWithSpecifiedConstraints() throws InvalidGateException
+	{
+		// given
+		Document.V11 document = factory.newDocument(
+				this.getClass()
+						.getResource( "/eu.cessda.cmv.core.FixedValueNodeConstraintTest/13-document-invalid-1.xml" )
+		);
+		Profile profile = factory.newProfile(
+				this.getClass().getResource( "/demo-documents/ddi-v25/cdc25_profile.xml" )
+		);
+
+		ValidationGate.V10 validationGate = ValidationGate.V10.newValidationGate( Arrays.asList(
+				FixedValueNodeConstraint.class.getSimpleName(),
+				MandatoryNodeConstraint.class.getSimpleName()
+		) );
+
+		List<ConstraintViolation> constraintViolations = validationGate.validate( document, profile );
+		List<String> messages = constraintViolations.stream()
+				.map( ConstraintViolation::getMessage )
+				.collect( Collectors.toList() );
+
+		// Assert that both the constraints were enforced
+		assertThat( messages, hasItem( containsString( "mandatory" ) ) );
+		assertThat( messages, hasItem( containsString( "fixed value" ) ) );
+	}
+
+	@SuppressWarnings( "unchecked" )
+	@Test
+	void shouldThrowIfAnInvalidConstraintIsRequested()
+	{
+		// InvalidGate is not a class, Validator is a class but isn't a constraint
+		InvalidGateException invalidGateException = assertThrows( InvalidGateException.class, () ->
+				ValidationGate.V10.newValidationGate( Arrays.asList( "InvalidGate", "Validator" ) )
+		);
+
+		// Assert that both types of error were thrown
+		assertThat(
+				Arrays.asList( invalidGateException.getSuppressed() ),
+				everyItem( instanceOf( InvalidConstraintException.class ) )
+		);
+		assertThat(
+				Arrays.stream( invalidGateException.getSuppressed() ).map( Throwable::getCause )
+						.collect( Collectors.toList() ),
+				hasItems( instanceOf( ClassNotFoundException.class ), instanceOf( ClassCastException.class ) )
+		);
+	}
+}

--- a/src/test/java/eu/cessda/cmv/core/CustomConstraintTest.java
+++ b/src/test/java/eu/cessda/cmv/core/CustomConstraintTest.java
@@ -26,7 +26,7 @@ class CustomConstraintTest
 				this.getClass().getResource( "/demo-documents/ddi-v25/cdc25_profile.xml" )
 		);
 
-		ValidationGate.V10 validationGate = ValidationGate.V10.newValidationGate( Arrays.asList(
+		ValidationGate.V10 validationGate = CessdaMetadataValidatorFactory.newValidationGate( Arrays.asList(
 				FixedValueNodeConstraint.class.getSimpleName(),
 				MandatoryNodeConstraint.class.getSimpleName()
 		) );
@@ -47,7 +47,7 @@ class CustomConstraintTest
 	{
 		// InvalidGate is not a class, Validator is a class but isn't a constraint
 		InvalidGateException invalidGateException = assertThrows( InvalidGateException.class, () ->
-				ValidationGate.V10.newValidationGate( Arrays.asList( "InvalidGate", "Validator" ) )
+				CessdaMetadataValidatorFactory.newValidationGate( Arrays.asList( "InvalidGate", "Validator" ) )
 		);
 
 		// Assert that both types of error were thrown
@@ -56,7 +56,8 @@ class CustomConstraintTest
 				everyItem( instanceOf( InvalidConstraintException.class ) )
 		);
 		assertThat(
-				Arrays.stream( invalidGateException.getSuppressed() ).map( Throwable::getCause )
+				Arrays.stream( invalidGateException.getSuppressed() )
+						.map( Throwable::getCause )
 						.collect( Collectors.toList() ),
 				hasItems( instanceOf( ClassNotFoundException.class ), instanceOf( ClassCastException.class ) )
 		);

--- a/src/test/java/eu/cessda/cmv/core/controlledvocabulary/EmptyControlledVocabularyRepositoryTest.java
+++ b/src/test/java/eu/cessda/cmv/core/controlledvocabulary/EmptyControlledVocabularyRepositoryTest.java
@@ -1,0 +1,65 @@
+/*-
+ * #%L
+ * cmv-core
+ * %%
+ * Copyright (C) 2020 - 2023 CESSDA ERIC
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package eu.cessda.cmv.core.controlledvocabulary;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.UUID;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+class EmptyControlledVocabularyRepositoryTest
+{
+
+	@Test
+	void shouldReturnEmptyCodeValues()
+	{
+		EmptyControlledVocabularyRepository repository = new EmptyControlledVocabularyRepository();
+
+		// Code values should be empty
+		assertThat( repository.findCodeValues(), is( empty() ) );
+	}
+
+	@Test
+	void shouldReturnEmptyDescriptiveTerms()
+	{
+		EmptyControlledVocabularyRepository repository = new EmptyControlledVocabularyRepository();
+
+		// Code values should be empty
+		assertThat( repository.findDescriptiveTerms(), is( empty() ) );
+	}
+
+	@Test
+	void shouldReturnAValidRandomUUID()
+	{
+		EmptyControlledVocabularyRepository repository = new EmptyControlledVocabularyRepository();
+
+		// Retrive the UUID
+		URI uri = repository.getUri();
+		String uuidString = uri.getSchemeSpecificPart().split( ":" )[1];
+
+		// Check if the UUID is valid
+		assertDoesNotThrow( () -> UUID.fromString( uuidString ) );
+	}
+}


### PR DESCRIPTION
These custom gates can have any combination of constraints enabled. APIs have also been added to allow users to use these gates to run validations and a method has been added to get the list of all known constraints.

This closes #118.