### PR TITLE
Refactor ConstraintViolation.getMessage() to only return the message

### DIFF
--- a/src/main/java/eu/cessda/cmv/core/ConstraintViolation.java
+++ b/src/main/java/eu/cessda/cmv/core/ConstraintViolation.java
@@ -40,18 +40,24 @@ public class ConstraintViolation
 
 	public String getMessage()
 	{
-		if ( locationInfo != null )
-		{
-			return message + " (lineNumber: " + locationInfo.getLineNumber() + ")";
-		}
-		else
-		{
-			return message;
-		}
+		return message;
 	}
 
 	public Optional<LocationInfo> getLocationInfo()
 	{
 		return Optional.ofNullable( locationInfo );
+	}
+
+	@Override
+	public String toString()
+	{
+		if ( locationInfo != null )
+		{
+			return message + " (lineNumber: " + locationInfo.getLineNumber() + ", columnNumber: " + locationInfo.getColumnNumber() + ")";
+		}
+		else
+		{
+			return message;
+		}
 	}
 }

--- a/src/main/java/eu/cessda/cmv/core/ValidationServiceImpl.java
+++ b/src/main/java/eu/cessda/cmv/core/ValidationServiceImpl.java
@@ -27,8 +27,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 class ValidationServiceImpl implements ValidationService
 {
@@ -94,13 +94,16 @@ class ValidationServiceImpl implements ValidationService
 	{
 		List<eu.cessda.cmv.core.ConstraintViolation> constraintViolations = validationGate.validate( document, profile );
 
-		ValidationReport validationReport = new ValidationReport();
-		validationReport.setDocumentUri( documentUri );
-		validationReport.setConstraintViolations( constraintViolations.stream()
-				.map( ConstraintViolation::new )
-				.collect( Collectors.toList() ) );
+		// Transform all constraint violations into the media-type form
+		List<ConstraintViolation> mediaTypeConstraintViolations = new ArrayList<>( constraintViolations.size() );
+		for ( eu.cessda.cmv.core.ConstraintViolation constraintViolation : constraintViolations )
+		{
+			ConstraintViolation mediaTypeViolation = new ConstraintViolation( constraintViolation );
+			mediaTypeConstraintViolations.add( mediaTypeViolation );
+		}
 
-		return validationReport;
+		// Create the validation report
+		return new ValidationReport( documentUri, mediaTypeConstraintViolations );
 	}
 
 	@Override

--- a/src/main/java/eu/cessda/cmv/core/mediatype/validationreport/ConstraintViolation.java
+++ b/src/main/java/eu/cessda/cmv/core/mediatype/validationreport/ConstraintViolation.java
@@ -67,6 +67,18 @@ public class ConstraintViolation
 		this.locationInfo = locationInfo;
 	}
 
+	public String toString()
+	{
+		if ( locationInfo != null )
+		{
+			return message + " (lineNumber: " + locationInfo.getLineNumber() + ", columnNumber: " + locationInfo.getColumnNumber() + ")";
+		}
+		else
+		{
+			return message;
+		}
+	}
+
 	@Override
 	public boolean equals( Object o )
 	{

--- a/src/main/java/eu/cessda/cmv/core/mediatype/validationreport/LocationInfo.java
+++ b/src/main/java/eu/cessda/cmv/core/mediatype/validationreport/LocationInfo.java
@@ -66,6 +66,12 @@ public class LocationInfo
 	}
 
 	@Override
+	public String toString()
+	{
+		return "lineNumber: " + lineNumber + ", columnNumber: " + columnNumber;
+	}
+
+	@Override
 	public boolean equals( Object o )
 	{
 		if ( this == o ) return true;

--- a/src/main/java/eu/cessda/cmv/core/mediatype/validationreport/ValidationReport.java
+++ b/src/main/java/eu/cessda/cmv/core/mediatype/validationreport/ValidationReport.java
@@ -42,8 +42,7 @@ public class ValidationReport extends JaxbDocument
 	static final String MAJOR = "0";
 	static final String MINOR = "1";
 	static final String VERSION = MAJOR + "." + MINOR;
-	public static final String MEDIATYPE = "application/vnd.eu.cessda.cmv.core.mediatype.validation-report.v" + VERSION
-			+ "+xml";
+	public static final String MEDIATYPE = "application/vnd.eu.cessda.cmv.core.mediatype.validation-report.v" + VERSION + "+xml";
 	static final String SCHEMALOCATION_HOST = "https://raw.githubusercontent.com/cessda/cessda.cmv.core/stable/schema";
 	public static final String SCHEMALOCATION_FILENAME = "validation-report-v" + VERSION + ".xsd";
 
@@ -77,6 +76,13 @@ public class ValidationReport extends JaxbDocument
 	{
 		super( SCHEMALOCATION, new DefaultNamespacePrefixMapper( NAMESPACE_DEFAULT_URI ) );
 		constraintViolations = new ArrayList<>();
+	}
+
+	public ValidationReport( URI documentUri, List<ConstraintViolation> constraintViolations )
+	{
+		this();
+		this.documentUri = documentUri;
+		this.constraintViolations = constraintViolations;
 	}
 
 	public List<ConstraintViolation> getConstraintViolations()
@@ -134,7 +140,7 @@ public class ValidationReport extends JaxbDocument
 	@Override
 	public String toString()
 	{
-		return toString( JAXBCONTEXT );
+		return "documentUri: " + documentUri + ", constraintViolations: " + constraintViolations;
 	}
 
 	@Override

--- a/src/test/java/eu/cessda/cmv/core/CodeValueOfControlledVocabularyConstraintTest.java
+++ b/src/test/java/eu/cessda/cmv/core/CodeValueOfControlledVocabularyConstraintTest.java
@@ -61,8 +61,8 @@ class CodeValueOfControlledVocabularyConstraintTest
 
 		// then
 		assertThat( constraintViolations, hasSize( 1 ) );
-		assertThat( constraintViolations.get( 0 ).getMessage(),
-				equalTo( "Code value 'Person' in '/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept' is not element of the controlled vocabulary in 'https://vocabularies.cessda.eu/v2/vocabularies/AnalysisUnit/2.0?languageVersion=en-2.0' (lineNumber: 16)" ) );
+		assertThat( constraintViolations.get( 0 ).toString(),
+				equalTo( "Code value 'Person' in '/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept' is not element of the controlled vocabulary in 'https://vocabularies.cessda.eu/v2/vocabularies/AnalysisUnit/2.0?languageVersion=en-2.0' (lineNumber: 16, columnNumber: 113)" ) );
 	}
 
 	@Test
@@ -77,8 +77,8 @@ class CodeValueOfControlledVocabularyConstraintTest
 
 		// then
 		assertThat( constraintViolations, hasSize( 1 ) );
-		assertThat( constraintViolations.get( 0 ).getMessage(),
-				equalTo( "Code value 'Family.HouseholdFamily' in '/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept' cannot be validated because no controlled vocabulary is declared (lineNumber: 28)" ) );
+		assertThat( constraintViolations.get( 0 ).toString(),
+				equalTo( "Code value 'Family.HouseholdFamily' in '/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept' cannot be validated because no controlled vocabulary is declared (lineNumber: 28, columnNumber: 30)" ) );
 	}
 
 	@Test

--- a/src/test/java/eu/cessda/cmv/core/DescriptiveTermOfControlledVocabularyConstraintTest.java
+++ b/src/test/java/eu/cessda/cmv/core/DescriptiveTermOfControlledVocabularyConstraintTest.java
@@ -75,8 +75,8 @@ class DescriptiveTermOfControlledVocabularyConstraintTest
 
 		// then
 		assertThat( constraintViolations, hasSize( 1 ) );
-		assertThat( constraintViolations.get( 0 ).getMessage(),
-				equalTo( "Descriptive term 'Family.HouseholdFamily' in '/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit' is not element of the controlled vocabulary in 'https://vocabularies.cessda.eu/v2/vocabularies/AnalysisUnit/2.0?languageVersion=en-2.0' (lineNumber: 28)" ) );
+		assertThat( constraintViolations.get( 0 ).toString(),
+				equalTo( "Descriptive term 'Family.HouseholdFamily' in '/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit' is not element of the controlled vocabulary in 'https://vocabularies.cessda.eu/v2/vocabularies/AnalysisUnit/2.0?languageVersion=en-2.0' (lineNumber: 28, columnNumber: 27)" ) );
 	}
 
 	@Test

--- a/src/test/java/eu/cessda/cmv/core/FixedValueNodeConstraintTest.java
+++ b/src/test/java/eu/cessda/cmv/core/FixedValueNodeConstraintTest.java
@@ -86,8 +86,8 @@ class FixedValueNodeConstraintTest
 
 		// then
 		assertThat( constraintViolations, hasSize( 1 ) );
-		assertThat( constraintViolations.get( 0 ).getMessage(),
-				equalTo( "'DDI Analyseeinheit' is not equal to fixed value 'DDI Analysis Unit' in '/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab' (lineNumber: 13)" ) );
+		assertThat( constraintViolations.get( 0 ).toString(),
+				equalTo( "'DDI Analyseeinheit' is not equal to fixed value 'DDI Analysis Unit' in '/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab' (lineNumber: 13, columnNumber: 44)" ) );
 	}
 
 	@Test

--- a/src/test/java/eu/cessda/cmv/core/mediatype/validationreport/ValidationReportTest.java
+++ b/src/test/java/eu/cessda/cmv/core/mediatype/validationreport/ValidationReportTest.java
@@ -19,7 +19,6 @@
  */
 package eu.cessda.cmv.core.mediatype.validationreport;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -31,7 +30,6 @@ import eu.cessda.cmv.core.ValidationService;
 import org.gesis.commons.resource.Resource;
 import org.gesis.commons.test.DefaultTestEnv;
 import org.gesis.commons.test.TestEnv;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -111,27 +109,19 @@ class ValidationReportTest
 
 	private void writeAndReadWithJackson( File file, PropertyNamingStrategy propertyNamingStrategy, ObjectMapper objectMapper ) throws IOException, NotDocumentException
 	{
-		try
-		{
-			objectMapper.setPropertyNamingStrategy( propertyNamingStrategy );
-			objectMapper.registerModule( new JaxbAnnotationModule() );
-			objectMapper.enable( SerializationFeature.INDENT_OUTPUT );
-			// objectMapper.setSerializationInclusion( Include.NON_NULL );
+		objectMapper.setPropertyNamingStrategy( propertyNamingStrategy );
+		objectMapper.registerModule( new JaxbAnnotationModule() );
+		objectMapper.enable( SerializationFeature.INDENT_OUTPUT );
+		// objectMapper.setSerializationInclusion( Include.NON_NULL );
 
-			ValidationReport validationReport = newValidationReport();
-			List<ConstraintViolation> constraintViolations = validationReport.getConstraintViolations();
-			String content = objectMapper.writeValueAsString( validationReport );
-			testEnv.writeContent( content, file );
-			assertThat( file, hasEqualContent( testEnv.findTestResourceByName( file.getName() ) ) );
+		ValidationReport validationReport = newValidationReport();
+		List<ConstraintViolation> constraintViolations = validationReport.getConstraintViolations();
+		String content = objectMapper.writeValueAsString( validationReport );
+		testEnv.writeContent( content, file );
+		assertThat( file, hasEqualContent( testEnv.findTestResourceByName( file.getName() ) ) );
 
-			validationReport = objectMapper.readValue( content, ValidationReport.class );
-			assertThat( validationReport.getConstraintViolations().size(), equalTo( constraintViolations.size() ) );
-		}
-		catch (JsonProcessingException e)
-		{
-			e.printStackTrace();
-			Assertions.fail( e.getMessage() );
-		}
+		validationReport = objectMapper.readValue( content, ValidationReport.class );
+		assertThat( validationReport.getConstraintViolations().size(), equalTo( constraintViolations.size() ) );
 	}
 
 	@Test


### PR DESCRIPTION
The functionality of ConstraintViolation.getMessage() has been moved to ConstraintViolation.toString().

A new constructor has been added to ValidationReport so that all fields can be set by the constructor.

This closes #172.