### PR TITLE
Convert Node to an interface, rename Node to NodeImpl

### DIFF
--- a/src/main/java/eu/cessda/cmv/core/ControlledVocabularyNode.java
+++ b/src/main/java/eu/cessda/cmv/core/ControlledVocabularyNode.java
@@ -22,7 +22,7 @@ package eu.cessda.cmv.core;
 import eu.cessda.cmv.core.controlledvocabulary.ControlledVocabularyRepository;
 import org.gesis.commons.xml.LocationInfo;
 
-class ControlledVocabularyNode extends Node
+class ControlledVocabularyNode extends NodeImpl
 {
 	private final ControlledVocabularyRepository controlledVocabularyRepository;
 

--- a/src/main/java/eu/cessda/cmv/core/ControlledVocabularyRepositoryConstraint.java
+++ b/src/main/java/eu/cessda/cmv/core/ControlledVocabularyRepositoryConstraint.java
@@ -46,6 +46,7 @@ class ControlledVocabularyRepositoryConstraint implements Constraint
 		this.uri = repositoryUri;
 	}
 
+	@SuppressWarnings( "OverlyBroadCatchBlock" )
 	@Override
 	public List<Validator> newValidators( Document document )
 	{

--- a/src/main/java/eu/cessda/cmv/core/DomCodebookDocument.java
+++ b/src/main/java/eu/cessda/cmv/core/DomCodebookDocument.java
@@ -57,7 +57,7 @@ class DomCodebookDocument implements Document
 		List<Node> nodes = new ArrayList<>();
 		for ( org.w3c.dom.Node domNode : document.selectNodes( locationPath ) )
 		{
-			Node node;
+			NodeImpl node;
 			if ( locationPath.equals( "/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit" )
 					|| locationPath.equals( "/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept" ) )
 			{
@@ -75,7 +75,7 @@ class DomCodebookDocument implements Document
 			}
 			else
 			{
-				node = new Node( locationPath, domNode.getTextContent(), document.getLocationInfo( domNode )
+				node = new NodeImpl( locationPath, domNode.getTextContent(), document.getLocationInfo( domNode )
 						.orElse( null ) );
 			}
 			countChildNodes( node, domNode );
@@ -96,7 +96,7 @@ class DomCodebookDocument implements Document
 		}
 	}
 
-	private void countChildNodes( Node node, org.w3c.dom.Node domNode )
+	private void countChildNodes( NodeImpl node, org.w3c.dom.Node domNode )
 	{
 		if ( domNode.getNodeType() == org.w3c.dom.Node.ELEMENT_NODE )
 		{

--- a/src/main/java/eu/cessda/cmv/core/Node.java
+++ b/src/main/java/eu/cessda/cmv/core/Node.java
@@ -2,14 +2,14 @@
  * #%L
  * cmv-core
  * %%
- * Copyright (C) 2020 - 2021 CESSDA ERIC
+ * Copyright (C) 2020 - 2023 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,60 +21,31 @@ package eu.cessda.cmv.core;
 
 import org.gesis.commons.xml.LocationInfo;
 
-import java.util.HashMap;
-
-import static java.util.Objects.requireNonNull;
-
-class Node
+public interface Node
 {
-	private final String locationPath;
-	private final String textContent;
-	private final LocationInfo locationInfo;
-	private final HashMap<String, Integer> childCounter = new HashMap<>();
+	/**
+	 * The XPath of this node in the document.
+	 */
+	String getLocationPath();
 
-	Node( String locationPath, String textContent, LocationInfo locationInfo )
-	{
-		requireNonNull( locationPath );
+	/**
+	 * The text content of this node and its descendants.
+	 */
+	String getTextContent();
 
-		this.locationPath = locationPath;
-		this.textContent = textContent;
-		this.locationInfo = locationInfo;
-	}
+	/**
+	 * The location of this node in the document.
+	 */
+	LocationInfo getLocationInfo();
 
-	public String getLocationPath()
-	{
-		return locationPath;
-	}
-
-	public String getTextContent()
-	{
-		return textContent;
-	}
-
-	public LocationInfo getLocationInfo()
-	{
-		return locationInfo;
-	}
-
-	public void incrementChildCount( String relativeLocationPath )
-	{
-		requireNonNull( relativeLocationPath );
-		childCounter.compute( relativeLocationPath, (path, counter) ->
-		{
-			if ( counter == null )
-			{
-				// Initialise the mapping with 1
-				return 1;
-			}
-			else
-			{
-				return counter + 1;
-			}
-		} );
-	}
-
-	public int getChildCount( String relativeLocationPath )
-	{
-		return childCounter.getOrDefault( relativeLocationPath, 0 );
-	}
+	/**
+	 * Returns the number of children of this node that satisfy the given XPath.
+	 * <p>
+	 * The XPath is resolved relative to this node. For example, a node at
+	 * {@code /node} and a relative location path of {@code ./child} would
+	 * be resolved to {@code /node/child}.
+	 *
+	 * @return the count of children that satisfy the given relative XPath.
+	 */
+	int getChildCount( String relativeLocationPath );
 }

--- a/src/main/java/eu/cessda/cmv/core/Node.java
+++ b/src/main/java/eu/cessda/cmv/core/Node.java
@@ -2,14 +2,14 @@
  * #%L
  * cmv-core
  * %%
- * Copyright (C) 2020 - 2023 CESSDA ERIC
+ * Copyright (C) 2020 - 2024 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/eu/cessda/cmv/core/NodeImpl.java
+++ b/src/main/java/eu/cessda/cmv/core/NodeImpl.java
@@ -1,0 +1,84 @@
+/*-
+ * #%L
+ * cmv-core
+ * %%
+ * Copyright (C) 2020 - 2021 CESSDA ERIC
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package eu.cessda.cmv.core;
+
+import org.gesis.commons.xml.LocationInfo;
+
+import java.util.HashMap;
+
+import static java.util.Objects.requireNonNull;
+
+class NodeImpl implements Node
+{
+	private final String locationPath;
+	private final String textContent;
+	private final LocationInfo locationInfo;
+	private final HashMap<String, Integer> childCounter = new HashMap<>();
+
+	NodeImpl( String locationPath, String textContent, LocationInfo locationInfo )
+	{
+		requireNonNull( locationPath );
+
+		this.locationPath = locationPath;
+		this.textContent = textContent;
+		this.locationInfo = locationInfo;
+	}
+
+	@Override
+	public String getLocationPath()
+	{
+		return locationPath;
+	}
+
+	@Override
+	public String getTextContent()
+	{
+		return textContent;
+	}
+
+	@Override
+	public LocationInfo getLocationInfo()
+	{
+		return locationInfo;
+	}
+
+	public void incrementChildCount( String relativeLocationPath )
+	{
+		requireNonNull( relativeLocationPath );
+		childCounter.compute( relativeLocationPath, (path, counter) ->
+		{
+			if ( counter == null )
+			{
+				// Initialise the mapping with 1
+				return 1;
+			}
+			else
+			{
+				return counter + 1;
+			}
+		} );
+	}
+
+	@Override
+	public int getChildCount( String relativeLocationPath )
+	{
+		return childCounter.getOrDefault( relativeLocationPath, 0 );
+	}
+}

--- a/src/main/java/eu/cessda/cmv/core/NodeImpl.java
+++ b/src/main/java/eu/cessda/cmv/core/NodeImpl.java
@@ -2,7 +2,7 @@
  * #%L
  * cmv-core
  * %%
- * Copyright (C) 2020 - 2021 CESSDA ERIC
+ * Copyright (C) 2020 - 2024 CESSDA ERIC
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/eu/cessda/cmv/core/NotBlankNodeValidator.java
+++ b/src/main/java/eu/cessda/cmv/core/NotBlankNodeValidator.java
@@ -37,7 +37,7 @@ class NotBlankNodeValidator implements Validator
 	@Override
 	public Optional<ConstraintViolation> validate()
 	{
-		boolean isBlank = node.getTextContent().trim().length() == 0;
+		boolean isBlank = node.getTextContent().trim().isEmpty();
 		if ( isBlank )
 		{
 			return ofNullable( newConstraintViolation() );

--- a/src/test/java/eu/cessda/cmv/core/BasicValidationGateTest.java
+++ b/src/test/java/eu/cessda/cmv/core/BasicValidationGateTest.java
@@ -67,7 +67,7 @@ class BasicValidationGateTest
 		// given
 		Document document = mock( Document.class );
 		when( document.getNodes( "/path/to/mandatory/node" ) )
-				.thenReturn( Collections.singletonList( new Node( "/path/to/mandatory/node", "at-least-one", null ) ) );
+				.thenReturn( Collections.singletonList( new NodeImpl( "/path/to/mandatory/node", "at-least-one", null ) ) );
 		Profile profile = mock( Profile.class );
 		when( profile.getConstraints() ).thenReturn( asList(
 				new MandatoryNodeConstraint( "/path/to/mandatory/node" ),

--- a/src/test/java/eu/cessda/cmv/core/CompilableXPathConstraintTest.java
+++ b/src/test/java/eu/cessda/cmv/core/CompilableXPathConstraintTest.java
@@ -96,7 +96,7 @@ class CompilableXPathConstraintTest
 	private Document mockDocument( String locationPath )
 	{
 		Document document = mock( Document.class );
-		Node node = new Node( "/DDIProfile/Used/@xpath", locationPath, null );
+		Node node = new NodeImpl( "/DDIProfile/Used/@xpath", locationPath, null );
 		when( document.getNodes( locationPath ) ).thenReturn( Collections.singletonList( node ) );
 		return document;
 	}

--- a/src/test/java/eu/cessda/cmv/core/ElementInSetValidatorTest.java
+++ b/src/test/java/eu/cessda/cmv/core/ElementInSetValidatorTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,18 +19,18 @@
  */
 package eu.cessda.cmv.core;
 
-import static org.gesis.commons.test.hamcrest.OptionalMatchers.isEmpty;
-import static org.gesis.commons.test.hamcrest.OptionalMatchers.isPresent;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import static org.gesis.commons.test.hamcrest.OptionalMatchers.isEmpty;
+import static org.gesis.commons.test.hamcrest.OptionalMatchers.isPresent;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.when;
 
 class ElementInSetValidatorTest
 {
@@ -49,7 +49,7 @@ class ElementInSetValidatorTest
 
 	private Node mockNode( String element )
 	{
-		Node node = Mockito.mock( Node.class );
+		Node node = Mockito.mock( NodeImpl.class );
 		when( node.getTextContent() ).thenReturn( element );
 		return node;
 	}

--- a/src/test/java/eu/cessda/cmv/core/NodeTest.java
+++ b/src/test/java/eu/cessda/cmv/core/NodeTest.java
@@ -29,7 +29,7 @@ class NodeTest
 	@Test
 	void getChildCount()
 	{
-		Node node = new Node( "/path/to/element", "value", null );
+		NodeImpl node = new NodeImpl( "/path/to/element", "value", null );
 		String locationPath = "./@attribute";
 		assertThat( node.getChildCount( locationPath ), equalTo( 0 ) );
 		node.incrementChildCount( locationPath );

--- a/src/test/java/eu/cessda/cmv/core/NotBlankNodeValidatorTest.java
+++ b/src/test/java/eu/cessda/cmv/core/NotBlankNodeValidatorTest.java
@@ -33,7 +33,7 @@ class NotBlankNodeValidatorTest
 	void validate_empty()
 	{
 		// given: empty text content
-		Node node = new Node( "/path/to/node", "", null );
+		Node node = new NodeImpl( "/path/to/node", "", null );
 		Validator validator = new NotBlankNodeValidator( node );
 
 		// when
@@ -47,7 +47,7 @@ class NotBlankNodeValidatorTest
 	void validate_blank()
 	{
 		// given: blank text content
-		Node node = new Node( "/path/to/node", "   ", null );
+		Node node = new NodeImpl( "/path/to/node", "   ", null );
 		Validator validator = new NotBlankNodeValidator( node );
 
 		// when
@@ -61,7 +61,7 @@ class NotBlankNodeValidatorTest
 	void validate_notBlank()
 	{
 		// given: not blank text content
-		Node node = new Node( "/path/to/node", "not blank", null );
+		Node node = new NodeImpl( "/path/to/node", "not blank", null );
 		Validator validator = new NotBlankNodeValidator( node );
 
 		// when

--- a/src/test/java/eu/cessda/cmv/core/PredicatelessXPathConstraintTest.java
+++ b/src/test/java/eu/cessda/cmv/core/PredicatelessXPathConstraintTest.java
@@ -90,7 +90,7 @@ class PredicatelessXPathConstraintTest
 	private Document mockDocument( String locationPath )
 	{
 		Document document = mock( Document.class );
-		Node node = new Node( "/DDIProfile/Used/@xpath", locationPath, null );
+		Node node = new NodeImpl( "/DDIProfile/Used/@xpath", locationPath, null );
 		when( document.getNodes( locationPath ) ).thenReturn( Collections.singletonList( node ) );
 		return document;
 	}


### PR DESCRIPTION
The public interface Document.getNodes() returned the package-private implementation class Node. This is now an interface with public methods to read the state of the DOM node.