### PR TITLE
Add support for correctly parsing XML namespaces

### DIFF
--- a/src/main/java/eu/cessda/cmv/core/AbstractProfile.java
+++ b/src/main/java/eu/cessda/cmv/core/AbstractProfile.java
@@ -19,6 +19,7 @@
  */
 package eu.cessda.cmv.core;
 
+import javax.xml.namespace.NamespaceContext;
 import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
@@ -37,12 +38,14 @@ public abstract class AbstractProfile implements Profile
 	protected final String profileName;
 	protected final String profileVersion;
 	protected final Set<Constraint> constraints;
+	private final NamespaceContext namespaceContext;
 
-	protected AbstractProfile( String profileName, String profileVersion, Set<Constraint> constraints )
+	protected AbstractProfile( String profileName, String profileVersion, Set<Constraint> constraints, NamespaceContext namespaceContext )
 	{
 		this.profileName = profileName;
 		this.profileVersion = profileVersion;
 		this.constraints = constraints;
+		this.namespaceContext = namespaceContext;
 	}
 
 	@Override
@@ -61,6 +64,11 @@ public abstract class AbstractProfile implements Profile
 	public Set<Constraint> getConstraints()
 	{
 		return Collections.unmodifiableSet( constraints );
+	}
+
+	@Override
+	public NamespaceContext getNamespaceContext() {
+		return namespaceContext;
 	}
 
 	/**

--- a/src/main/java/eu/cessda/cmv/core/AbstractValidationGate.java
+++ b/src/main/java/eu/cessda/cmv/core/AbstractValidationGate.java
@@ -19,10 +19,7 @@
  */
 package eu.cessda.cmv.core;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 import static java.util.Objects.requireNonNull;
 
@@ -67,5 +64,20 @@ abstract class AbstractValidationGate implements ValidationGate
 			}
 		}
 		return constraintViolations;
+	}
+
+	@Override
+	public boolean equals( Object o )
+	{
+		if ( this == o ) return true;
+		if ( !( o instanceof AbstractValidationGate ) ) return false;
+		AbstractValidationGate that = (AbstractValidationGate) o;
+		return Objects.equals( constraintTypes, that.constraintTypes );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hashCode( constraintTypes );
 	}
 }

--- a/src/main/java/eu/cessda/cmv/core/AbstractValidationGate.java
+++ b/src/main/java/eu/cessda/cmv/core/AbstractValidationGate.java
@@ -51,6 +51,10 @@ abstract class AbstractValidationGate implements ValidationGate
 		requireNonNull( document, "document is null" );
 		requireNonNull( profile, "profile is null" );
 
+		// Set the namespace context
+		document.setNamespaceContext( profile.getNamespaceContext() );
+
+		// Validate the document against the constraints
 		List<ConstraintViolation> constraintViolations = new ArrayList<>();
 		for ( Constraint constraint : profile.getConstraints() )
 		{
@@ -64,5 +68,4 @@ abstract class AbstractValidationGate implements ValidationGate
 		}
 		return constraintViolations;
 	}
-
 }

--- a/src/main/java/eu/cessda/cmv/core/CMVNamespaceContext.java
+++ b/src/main/java/eu/cessda/cmv/core/CMVNamespaceContext.java
@@ -1,5 +1,7 @@
 package eu.cessda.cmv.core;
 
+import eu.cessda.cmv.core.mediatype.profile.PrefixMap;
+
 import javax.xml.namespace.NamespaceContext;
 import java.util.*;
 
@@ -32,6 +34,14 @@ public class CMVNamespaceContext implements NamespaceContext
 	public CMVNamespaceContext( Map<String, String> bindings )
 	{
 		bindings.forEach( this::bindNamespaceURI );
+	}
+
+	CMVNamespaceContext( List<PrefixMap> prefixMaps )
+	{
+		for ( PrefixMap prefixMap : prefixMaps )
+		{
+			bindNamespaceURI( prefixMap.getPrefix(), prefixMap.getNamespace() );
+		}
 	}
 
 	@Override
@@ -174,6 +184,11 @@ public class CMVNamespaceContext implements NamespaceContext
 		{
 			return null;
 		}
+	}
+
+	Map<String, String> getAllBindings()
+	{
+		return Collections.unmodifiableMap( prefixToNamespaceURI );
 	}
 
 	/**

--- a/src/main/java/eu/cessda/cmv/core/CMVNamespaceContext.java
+++ b/src/main/java/eu/cessda/cmv/core/CMVNamespaceContext.java
@@ -1,0 +1,202 @@
+package eu.cessda.cmv.core;
+
+import javax.xml.namespace.NamespaceContext;
+import java.util.*;
+
+import static java.util.Objects.requireNonNull;
+import static javax.xml.XMLConstants.*;
+
+/**
+ * Fully compliant implementation of {@link NamespaceContext}.
+ */
+public class CMVNamespaceContext implements NamespaceContext
+{
+	private static final String PREFIX_NULL = "prefix is null";
+	private static final String NAMESPACE_URI_NULL = "namespaceURI is null";
+
+	private final HashMap<String, String> prefixToNamespaceURI = new HashMap<>();
+	private final HashMap<String, Set<String>> namespaceURIToPrefixes = new HashMap<>();
+
+	/**
+	 * Construct a new instance of NamespaceContext with no bindings.
+	 */
+	public CMVNamespaceContext()
+	{
+	}
+
+	/**
+	 * Construct a new instance of NamespaceContext with the bindings set using the given map.
+	 *
+	 * @param bindings the bindings to set, the prefix is the key, the namespace is the value.
+	 */
+	public CMVNamespaceContext( Map<String, String> bindings )
+	{
+		bindings.forEach( this::bindNamespaceURI );
+	}
+
+	@Override
+	public String getNamespaceURI( String prefix )
+	{
+		if (prefix == null)
+		{
+			throw new IllegalArgumentException( PREFIX_NULL );
+		}
+
+		switch ( prefix )
+		{
+			case DEFAULT_NS_PREFIX:
+				return NULL_NS_URI;
+			case XML_NS_PREFIX:
+				return XML_NS_URI;
+			case XMLNS_ATTRIBUTE:
+				return XMLNS_ATTRIBUTE_NS_URI;
+			default:
+				return prefixToNamespaceURI.getOrDefault( prefix, NULL_NS_URI );
+		}
+	}
+
+	@Override
+	public String getPrefix( String namespaceURI )
+	{
+		if ( namespaceURI == null )
+		{
+			throw new IllegalArgumentException( NAMESPACE_URI_NULL );
+		}
+
+		switch ( namespaceURI )
+		{
+			case NULL_NS_URI:
+				return DEFAULT_NS_PREFIX;
+			case XML_NS_URI:
+				return XML_NS_PREFIX;
+			case XMLNS_ATTRIBUTE_NS_URI:
+				return XMLNS_ATTRIBUTE;
+			default:
+				Set<String> prefixSet = namespaceURIToPrefixes.getOrDefault( namespaceURI, Collections.emptySet() );
+				return prefixSet.stream().findAny().orElse( null );
+		}
+	}
+
+	@Override
+	public Iterator<String> getPrefixes( String namespaceURI )
+	{
+		if ( namespaceURI == null )
+		{
+			throw new IllegalArgumentException( NAMESPACE_URI_NULL );
+		}
+
+		Set<String> prefixSet;
+		switch ( namespaceURI )
+		{
+			case XML_NS_URI:
+				prefixSet = Collections.singleton( XML_NS_PREFIX );
+				break;
+			case XMLNS_ATTRIBUTE_NS_URI:
+				prefixSet = Collections.singleton( XMLNS_ATTRIBUTE );
+				break;
+			default:
+				prefixSet = namespaceURIToPrefixes.getOrDefault( namespaceURI, Collections.emptySet() );
+				break;
+		}
+
+		return Collections.unmodifiableSet( prefixSet ).iterator();
+	}
+
+	/**
+	 * Bind the prefix to the given namespace URI
+	 *
+	 * @param prefix the prefix
+	 * @param namespaceURI the namespace to bind.
+	 * @return the previously bound namespace, or {@code null} if there was no binding.
+	 */
+	String bindNamespaceURI( String prefix, String namespaceURI )
+	{
+		requireNonNull( prefix, PREFIX_NULL );
+		requireNonNull( namespaceURI, NAMESPACE_URI_NULL );
+
+		// Fail mapping if the default prefixes are remapped
+		if ( prefix.equals( DEFAULT_NS_PREFIX ) || prefix.equals( XML_NS_PREFIX ) || prefix.equals( XMLNS_ATTRIBUTE ) )
+		{
+			throw new IllegalArgumentException( "Prefix \"" + prefix + "\" cannot be rebound" );
+		}
+
+		// Fail mapping if the default namespaces are remapped
+		if ( namespaceURI.equals( XML_NS_URI ) || namespaceURI.equals( XMLNS_ATTRIBUTE_NS_URI ) )
+		{
+			throw new IllegalArgumentException( "Namespace URI \"" + namespaceURI + "\" cannot be rebound" );
+		}
+
+		// Bind the prefix to the namespace URI
+		String oldNamespaceURI = prefixToNamespaceURI.put( prefix, namespaceURI );
+		if ( oldNamespaceURI != null )
+		{
+			// Remove the old prefix from the set of prefixes bound to the namespace URI
+			namespaceURIToPrefixes.get( oldNamespaceURI ).remove( prefix );
+		}
+
+		// Add the prefix to the namespace URI's set of prefixes
+		namespaceURIToPrefixes.computeIfAbsent( namespaceURI, k -> new HashSet<>() ).add( prefix );
+		return oldNamespaceURI;
+	}
+
+	/**
+	 * Remove the binding between a prefix and a namespace URI.
+	 *
+	 * @param prefix the prefix to unbind.
+	 * @return the namespace URI that was bound, or {@code null} if there was no binding.
+	 */
+	String removeBinding( String prefix )
+	{
+		Objects.requireNonNull( prefix, PREFIX_NULL );
+
+		// Fail mapping if the default prefixes are remapped
+		if ( prefix.equals( DEFAULT_NS_PREFIX ) || prefix.equals( XML_NS_PREFIX ) || prefix.equals( XMLNS_ATTRIBUTE ) )
+		{
+			throw new IllegalArgumentException( prefix + " cannot be unbound" );
+		}
+
+		// Remove the namespace URI from the prefix map
+		String namespaceURI = prefixToNamespaceURI.remove( prefix );
+		if ( namespaceURI != null )
+		{
+			// Remove the prefix from the set of prefixes bound to the namespace URI
+			Set<String> prefixes = namespaceURIToPrefixes.get( namespaceURI );
+			prefixes.remove( prefix );
+			if ( prefixes.isEmpty() )
+			{
+				// No more prefixes are bound to the namespace URI, remove the set
+				namespaceURIToPrefixes.remove( namespaceURI );
+			}
+
+			return namespaceURI;
+		}
+		else
+		{
+			return null;
+		}
+	}
+
+	/**
+	 * Clear all bindings from the NamespaceContext.
+	 */
+	void clear()
+	{
+		prefixToNamespaceURI.clear();
+		namespaceURIToPrefixes.clear();
+	}
+
+	@Override
+	public boolean equals( Object o )
+	{
+		if ( this == o ) return true;
+		if ( !( o instanceof CMVNamespaceContext ) ) return false;
+		CMVNamespaceContext that = (CMVNamespaceContext) o;
+		return Objects.equals( prefixToNamespaceURI, that.prefixToNamespaceURI );
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash( prefixToNamespaceURI );
+	}
+}

--- a/src/main/java/eu/cessda/cmv/core/CessdaMetadataValidatorFactory.java
+++ b/src/main/java/eu/cessda/cmv/core/CessdaMetadataValidatorFactory.java
@@ -263,6 +263,7 @@ public class CessdaMetadataValidatorFactory implements ValidationService
 		try
 		{
 			XMLDocument document = XMLDocument.newBuilder().build(inputSource);
+			document.setNamespaceContext( DomSemiStructuredDdiProfile.getProfileNamespaceContext() );
 			return new DomSemiStructuredDdiProfile( document );
 		}
 		catch ( SAXException e )
@@ -358,13 +359,14 @@ public class CessdaMetadataValidatorFactory implements ValidationService
 		try
 		{
 			// Parse the XML document
-			XMLDocument document = XMLDocument.newBuilder().locationInfoAware( true ).namespaceAware( true ).build( inputSource );
+			XMLDocument document = XMLDocument.newBuilder().locationInfoAware( true ).build( inputSource );
 			String namespace = document.getNamespace();
 
 			if ( OAI_PMH_XML_NAMESPACE.equals( namespace ))
 			{
 				// Try to extract <metadata> and recurse
-				document.setRootElement( "/oai:OAI-PMH/oai:GetRecord/oai:record/oai:metadata/*", "oai", OAI_PMH_XML_NAMESPACE );
+				CMVNamespaceContext namespaceContext = new CMVNamespaceContext( Collections.singletonMap( "oai", OAI_PMH_XML_NAMESPACE ) );
+				document.setRootElement( "/oai:OAI-PMH/oai:GetRecord/oai:record/oai:metadata/*", namespaceContext );
 			}
 
 			return new DomCodebookDocument( uri, document, cvrMap );

--- a/src/main/java/eu/cessda/cmv/core/ControlledVocabularyRepositoryConstraint.java
+++ b/src/main/java/eu/cessda/cmv/core/ControlledVocabularyRepositoryConstraint.java
@@ -88,6 +88,16 @@ class ControlledVocabularyRepositoryConstraint extends NodeConstraint
 	}
 
 	@Override
+	public String toString()
+	{
+		return "ControlledVocabularyRepositoryConstraint{" +
+			"locationPath='" + getLocationPath() + '\'' +
+			", type='" + type + '\'' +
+			", uri=" + uri +
+			'}';
+	}
+
+	@Override
 	public boolean equals( Object o )
 	{
 		if ( this == o ) return true;

--- a/src/main/java/eu/cessda/cmv/core/Document.java
+++ b/src/main/java/eu/cessda/cmv/core/Document.java
@@ -21,6 +21,7 @@ package eu.cessda.cmv.core;
 
 import eu.cessda.cmv.core.controlledvocabulary.ControlledVocabularyRepository;
 
+import javax.xml.namespace.NamespaceContext;
 import javax.xml.xpath.XPathExpressionException;
 import java.net.URI;
 import java.util.List;
@@ -59,4 +60,6 @@ public interface Document
 	 * @return the controlled vocabulary, or {@code null} if the uri was not registered.
 	 */
 	ControlledVocabularyRepository findControlledVocabularyRepository( URI uri );
+
+	void setNamespaceContext( NamespaceContext namespaceContext );
 }

--- a/src/main/java/eu/cessda/cmv/core/DomProfile.java
+++ b/src/main/java/eu/cessda/cmv/core/DomProfile.java
@@ -21,7 +21,6 @@ package eu.cessda.cmv.core;
 
 import java.io.InputStream;
 import java.util.LinkedHashSet;
-import java.util.Objects;
 
 class DomProfile extends AbstractProfile
 {
@@ -34,12 +33,9 @@ class DomProfile extends AbstractProfile
 		super(
 			profile.getName() != null ? profile.getName().trim() : null,
 			profile.getVersion() != null ? profile.getVersion().trim() : null,
-			new LinkedHashSet<>(),
-			new CMVNamespaceContext()
+			new LinkedHashSet<>(profile.getConstraints().size()),
+			new CMVNamespaceContext(profile.getPrefixMap())
 		);
-
-		// Validate constraints list is not null
-		Objects.requireNonNull( profile.getConstraints(), "profile constraints must not be null" );
 
 		for ( eu.cessda.cmv.core.mediatype.profile.Constraint constraint : profile.getConstraints() )
 		{

--- a/src/main/java/eu/cessda/cmv/core/DomProfile.java
+++ b/src/main/java/eu/cessda/cmv/core/DomProfile.java
@@ -34,7 +34,8 @@ class DomProfile extends AbstractProfile
 		super(
 			profile.getName() != null ? profile.getName().trim() : null,
 			profile.getVersion() != null ? profile.getVersion().trim() : null,
-			new LinkedHashSet<>()
+			new LinkedHashSet<>(),
+			new CMVNamespaceContext()
 		);
 
 		// Validate constraints list is not null

--- a/src/main/java/eu/cessda/cmv/core/DomSemiStructuredDdiProfile.java
+++ b/src/main/java/eu/cessda/cmv/core/DomSemiStructuredDdiProfile.java
@@ -19,6 +19,7 @@
  */
 package eu.cessda.cmv.core;
 
+import eu.cessda.cmv.core.mediatype.profile.PrefixMap;
 import org.gesis.commons.xml.XMLDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,10 +35,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayDeque;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 class DomSemiStructuredDdiProfile extends AbstractProfile
 {
@@ -425,9 +423,25 @@ class DomSemiStructuredDdiProfile extends AbstractProfile
 		eu.cessda.cmv.core.mediatype.profile.Profile jaxbProfile = new eu.cessda.cmv.core.mediatype.profile.Profile();
 		List<eu.cessda.cmv.core.mediatype.profile.Constraint> jaxbConstraints = jaxbProfile.getConstraints();
 
-		// Set the name of the profile
+		// Set the name and version of the profile
 		jaxbProfile.setName( profileName );
+		jaxbProfile.setVersion( profileVersion );
 
+		// Set the namespace context
+		List<PrefixMap> prefixMaps = new ArrayList<>();
+
+		// This will always be an instance of CMVNamespaceContext, so this is a safe cast
+		CMVNamespaceContext namespaceContext = (CMVNamespaceContext) getNamespaceContext();
+		for( Map.Entry<String, String> binding : namespaceContext.getAllBindings().entrySet() )
+		{
+			PrefixMap prefixMap = new PrefixMap();
+			prefixMap.setPrefix( binding.getKey() );
+			prefixMap.setNamespace( binding.getValue() );
+			prefixMaps.add( prefixMap );
+		}
+		jaxbProfile.setPrefixMap(prefixMaps);
+
+		// Set constraints
 		for ( Constraint constraint : constraints )
 		{
 			String locationPath = null;

--- a/src/main/java/eu/cessda/cmv/core/EmptyControlledVocabularyRepository.java
+++ b/src/main/java/eu/cessda/cmv/core/EmptyControlledVocabularyRepository.java
@@ -30,8 +30,8 @@ import static java.util.Collections.emptySet;
 class EmptyControlledVocabularyRepository implements ControlledVocabularyRepository
 {
 	// Use the nil UUID for all instances
-	private static final UUID UUID = new UUID( 0, 0 );
-	private static final URI uri = URI.create( "urn:uuid:" + UUID );
+	private static final UUID NIL_UUID = new UUID( 0, 0 );
+	private static final URI NIL_URI = URI.create( "urn:uuid:" + NIL_UUID );
 
 	/**
 	 * The common instance for all EmptyControlledVocabularyRepository objects.
@@ -55,6 +55,6 @@ class EmptyControlledVocabularyRepository implements ControlledVocabularyReposit
 	@Override
 	public URI getUri()
 	{
-		return uri;
+		return NIL_URI;
 	}
 }

--- a/src/main/java/eu/cessda/cmv/core/FixedValueNodeConstraint.java
+++ b/src/main/java/eu/cessda/cmv/core/FixedValueNodeConstraint.java
@@ -74,6 +74,15 @@ class FixedValueNodeConstraint extends NodeConstraint
 	}
 
 	@Override
+	public String toString()
+	{
+		return "FixedValueNodeConstraint{" +
+			"locationPath='" + getLocationPath() + '\'' +
+			", fixedValue='" + fixedValue + '\'' +
+			'}';
+	}
+
+	@Override
 	public boolean equals( Object o )
 	{
 		if ( this == o ) return true;

--- a/src/main/java/eu/cessda/cmv/core/MaximumElementOccurrenceConstraint.java
+++ b/src/main/java/eu/cessda/cmv/core/MaximumElementOccurrenceConstraint.java
@@ -47,6 +47,15 @@ class MaximumElementOccurrenceConstraint extends NodeConstraint
 	}
 
 	@Override
+	public String toString()
+	{
+		return "MaximumElementOccurrenceConstraint{" +
+			"locationPath='" + getLocationPath() + '\'' +
+			", maxOccurs=" + maxOccurs +
+			'}';
+	}
+
+	@Override
 	public boolean equals( Object o )
 	{
 		if ( this == o ) return true;

--- a/src/main/java/eu/cessda/cmv/core/NodeConstraint.java
+++ b/src/main/java/eu/cessda/cmv/core/NodeConstraint.java
@@ -73,6 +73,12 @@ abstract class NodeConstraint implements Constraint
 	}
 
 	@Override
+	public String toString()
+	{
+		return this.getClass().getSimpleName() + "{" + "locationPath='" + locationPath + '\'' + '}';
+	}
+
+	@Override
 	public boolean equals( Object o )
 	{
 		if ( this == o ) return true;

--- a/src/main/java/eu/cessda/cmv/core/NotDocumentException.java
+++ b/src/main/java/eu/cessda/cmv/core/NotDocumentException.java
@@ -19,15 +19,18 @@
  */
 package eu.cessda.cmv.core;
 
-import static java.lang.String.format;
-
 public class NotDocumentException extends Exception
 {
 	private static final long serialVersionUID = -2148512119063297931L;
 
-	NotDocumentException( String mediaType )
+	NotDocumentException( String message )
 	{
-		super( format( "Not CMV document: Detected media type: %s", mediaType ) );
+		super( message );
+	}
+
+	NotDocumentException( String message, Throwable throwable )
+	{
+		super( message, throwable );
 	}
 
 	NotDocumentException( Throwable throwable )

--- a/src/main/java/eu/cessda/cmv/core/Profile.java
+++ b/src/main/java/eu/cessda/cmv/core/Profile.java
@@ -19,6 +19,7 @@
  */
 package eu.cessda.cmv.core;
 
+import javax.xml.namespace.NamespaceContext;
 import java.util.Set;
 
 /**
@@ -48,4 +49,6 @@ public interface Profile
 	 * @return a set of constraints.
 	 */
 	Set<Constraint> getConstraints();
+
+	NamespaceContext getNamespaceContext();
 }

--- a/src/main/java/eu/cessda/cmv/core/mediatype/profile/PrefixMap.java
+++ b/src/main/java/eu/cessda/cmv/core/mediatype/profile/PrefixMap.java
@@ -1,0 +1,32 @@
+package eu.cessda.cmv.core.mediatype.profile;
+
+import javax.xml.bind.annotation.XmlElement;
+
+public class PrefixMap
+{
+	@XmlElement
+	private String prefix;
+
+	@XmlElement
+	private String namespace;
+
+	public String getPrefix()
+	{
+		return prefix;
+	}
+
+	public void setPrefix( String prefix )
+	{
+		this.prefix = prefix;
+	}
+
+	public String getNamespace()
+	{
+		return namespace;
+	}
+
+	public void setNamespace( String namespace )
+	{
+		this.namespace = namespace;
+	}
+}

--- a/src/main/java/eu/cessda/cmv/core/mediatype/profile/Profile.java
+++ b/src/main/java/eu/cessda/cmv/core/mediatype/profile/Profile.java
@@ -19,6 +19,7 @@
  */
 package eu.cessda.cmv.core.mediatype.profile;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.gesis.commons.xml.jaxb.DefaultNamespacePrefixMapper;
 import org.gesis.commons.xml.jaxb.JaxbDocument;
 
@@ -38,7 +39,7 @@ import java.util.Objects;
 public class Profile extends JaxbDocument
 {
 	static final String MAJOR = "0";
-	static final String MINOR = "1";
+	static final String MINOR = "2";
 	static final String VERSION = MAJOR + "." + MINOR;
 	public static final String MEDIATYPE = "application/vnd.eu.cessda.cmv.core.mediatype.profile.v" + VERSION + "+xml";
 	static final String SCHEMALOCATION_HOST = "https://raw.githubusercontent.com/cessda/cessda.cmv.core/stable/schema";
@@ -59,6 +60,11 @@ public class Profile extends JaxbDocument
 
 	@XmlElement
 	private String version;
+
+	@JsonProperty( "prefixMaps" )
+	@XmlElement( name = "PrefixMap" )
+	@XmlElementWrapper( name = "PrefixMaps" )
+	private List<PrefixMap> prefixMap;
 
 	@XmlElements( {
 			@XmlElement(
@@ -116,6 +122,16 @@ public class Profile extends JaxbDocument
 	public void setVersion( String version )
 	{
 		this.version = version;
+	}
+
+	public List<PrefixMap> getPrefixMap()
+	{
+		return prefixMap;
+	}
+
+	public void setPrefixMap( List<PrefixMap> prefixMap )
+	{
+		this.prefixMap = prefixMap;
 	}
 
 	public List<Constraint> getConstraints()

--- a/src/main/java/eu/cessda/cmv/core/mediatype/profile/Profile.java
+++ b/src/main/java/eu/cessda/cmv/core/mediatype/profile/Profile.java
@@ -40,10 +40,10 @@ public class Profile extends JaxbDocument
 {
 	static final String MAJOR = "0";
 	static final String MINOR = "2";
-	static final String VERSION = MAJOR + "." + MINOR;
-	public static final String MEDIATYPE = "application/vnd.eu.cessda.cmv.core.mediatype.profile.v" + VERSION + "+xml";
+	static final String SCHEMA_VERSION = MAJOR + "." + MINOR;
+	public static final String MEDIATYPE = "application/vnd.eu.cessda.cmv.core.mediatype.profile.v" + SCHEMA_VERSION + "+xml";
 	static final String SCHEMALOCATION_HOST = "https://raw.githubusercontent.com/cessda/cessda.cmv.core/stable/schema";
-	public static final String SCHEMALOCATION_FILENAME = "profile-v" + VERSION + ".xsd";
+	public static final String SCHEMALOCATION_FILENAME = "profile-v" + SCHEMA_VERSION + ".xsd";
 
 	static final String NAMESPACE_DEFAULT_PREFIX = "";
 	static final String NAMESPACE_DEFAULT_URI = "cmv:profile:v" + MAJOR;

--- a/src/main/java/eu/cessda/cmv/core/mediatype/profile/Profile.java
+++ b/src/main/java/eu/cessda/cmv/core/mediatype/profile/Profile.java
@@ -126,6 +126,11 @@ public class Profile extends JaxbDocument
 
 	public List<PrefixMap> getPrefixMap()
 	{
+		if (prefixMap == null)
+		{
+			// Instance prefixMap if null, ensures getPrefixMap() cannot return null
+			prefixMap = new ArrayList<>(0);
+		}
 		return prefixMap;
 	}
 
@@ -136,6 +141,11 @@ public class Profile extends JaxbDocument
 
 	public List<Constraint> getConstraints()
 	{
+		if (constraints == null)
+		{
+			// Instance constraints if null, ensures getConstraints() cannot return null
+			constraints = new ArrayList<>(0);
+		}
 		return constraints;
 	}
 

--- a/src/main/java/org/gesis/commons/xml/XMLDocument.java
+++ b/src/main/java/org/gesis/commons/xml/XMLDocument.java
@@ -19,13 +19,18 @@
  */
 package org.gesis.commons.xml;
 
-import org.w3c.dom.*;
+import eu.cessda.cmv.core.CMVNamespaceContext;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXNotRecognizedException;
 import org.xml.sax.SAXNotSupportedException;
 
 import javax.xml.XMLConstants;
+import javax.xml.namespace.NamespaceContext;
 import javax.xml.parsers.*;
 import javax.xml.xpath.*;
 import java.io.IOException;
@@ -33,7 +38,6 @@ import java.util.*;
 
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
-import static javax.xml.XMLConstants.XMLNS_ATTRIBUTE;
 import static javax.xml.xpath.XPathConstants.NODESET;
 
 /**
@@ -43,12 +47,12 @@ public class XMLDocument
 {
 
 	private final Document document;
-	private final SimpleNamespaceContext namespaceContext;
-    private final boolean isNamespaceAware;
-    private final XPathFactory xPathFactory = XPathFactory.newInstance();
+	private final XPathFactory xPathFactory = XPathFactory.newInstance();
 	private final Map<String, XPathExpression> xPathExpressionMap = new HashMap<>();
 
-	private XMLDocument( Document document, int prettyPrintIndentation, boolean isNamespaceAware )
+	private NamespaceContext namespaceContext = new CMVNamespaceContext();
+
+	private XMLDocument( Document document, int prettyPrintIndentation )
     {
 		if ( prettyPrintIndentation < 0 )
 		{
@@ -56,8 +60,11 @@ public class XMLDocument
 		}
 
         this.document = document;
-		this.isNamespaceAware = isNamespaceAware;
-		this.namespaceContext = getSimpleNamespaceContext(document);
+	}
+
+	public void setNamespaceContext(NamespaceContext namespaceContext)
+	{
+		this.namespaceContext = namespaceContext;
 	}
 
 	/**
@@ -65,14 +72,11 @@ public class XMLDocument
 	 * The document is modified by this method.
 	 *
 	 * @param location the XPath of the element that should become the root.
-	 * @param prefix the prefix of the namespace.
-	 * @param namespace the namespace.
+	 * @param nsContext the namespace context of the XPath.
 	 * @throws XPathExpressionException if the XPath cannot be evaluated.
 	 */
-	public void setRootElement( String location, String prefix, String namespace ) throws XPathExpressionException
+	public void setRootElement( String location, NamespaceContext nsContext ) throws XPathExpressionException
 	{
-		NamespaceContext nsContext = new NamespaceContext(Collections.singletonMap( prefix, namespace ));
-
 		XPath xpath = xPathFactory.newXPath();
 		xpath.setNamespaceContext( nsContext );
 		XPathExpression metadataXPath = xpath.compile( location );
@@ -91,28 +95,6 @@ public class XMLDocument
 		{
 			throw new XPathExpressionException("No element matching " + location + " found");
 		}
-	}
-
-	private static SimpleNamespaceContext getSimpleNamespaceContext(Document document)
-	{
-		SimpleNamespaceContext simpleNamespaceContext = new SimpleNamespaceContext( false );
-		Element documentElement = document.getDocumentElement();
-		if ( documentElement != null )
-		{
-			NamedNodeMap documentElementAttributes = documentElement.getAttributes();
-			for ( int i = 0; i < documentElementAttributes.getLength(); i++ )
-			{
-				Node attribute = documentElementAttributes.item( i );
-				if ( attribute.getNodeName().startsWith( XMLNS_ATTRIBUTE ) )
-				{
-					simpleNamespaceContext.bindNamespaceUri(
-						attribute.getNodeName().replaceAll( "xmlns:?", "" ),
-						attribute.getNodeValue()
-					);
-				}
-			}
-		}
-		return simpleNamespaceContext;
 	}
 
 	public Node selectNode( String xPath ) throws XPathExpressionException
@@ -154,16 +136,8 @@ public class XMLDocument
         {
 			// XPathExpression is not cached, compile
             XPath xpath = xPathFactory.newXPath();
-
-            if ( isNamespaceAware )
-            {
-                xpath.setNamespaceContext( namespaceContext );
-                xPathExpression = xpath.compile( namespaceContext.decorateDefaultNamespace( locationPath ) );
-            }
-            else
-            {
-                xPathExpression = xpath.compile( locationPath );
-            }
+			xpath.setNamespaceContext( namespaceContext );
+			xPathExpression = xpath.compile( locationPath  );
 
 			// Cache the compiled XPathExpression for future use
             xPathExpressionMap.put( locationPath, xPathExpression );
@@ -193,7 +167,7 @@ public class XMLDocument
 
 	public static class Builder
 	{
-		private static final ThreadLocal<DocumentBuilder> namespaceAwareDocumentBuilder = ThreadLocal.withInitial( () -> {
+		private static final ThreadLocal<DocumentBuilder> documentBuilder = ThreadLocal.withInitial( () -> {
 			try
 			{
 				DocumentBuilderFactory factory = getDocumentBuilderFactory();
@@ -206,39 +180,11 @@ public class XMLDocument
 			}
 		} );
 
-		private static final ThreadLocal<DocumentBuilder> namespaceUnawareDocumentBuilder = ThreadLocal.withInitial( () -> {
-			try
-			{
-				DocumentBuilderFactory factory = getDocumentBuilderFactory();
-				factory.setNamespaceAware( false );
-				return factory.newDocumentBuilder();
-			}
-			catch ( ParserConfigurationException e )
-			{
-				throw new IllegalStateException(e);
-			}
-		} );
-
-
-
-		private static final ThreadLocal<SAXParser> namespaceAwareSAXParser = ThreadLocal.withInitial( () -> {
+		private static final ThreadLocal<SAXParser> saxParser = ThreadLocal.withInitial( () -> {
 			try
 			{
 				SAXParserFactory factory = getSaxParserFactory();
 				factory.setNamespaceAware( true );
-				return factory.newSAXParser();
-			}
-			catch ( ParserConfigurationException | SAXException e )
-			{
-				throw new IllegalStateException(e);
-			}
-		} );
-
-		private static final ThreadLocal<SAXParser> namespaceUnawareSAXParser = ThreadLocal.withInitial( () -> {
-			try
-			{
-				SAXParserFactory factory = getSaxParserFactory();
-				factory.setNamespaceAware( false );
 				return factory.newSAXParser();
 			}
 			catch ( ParserConfigurationException | SAXException e )
@@ -305,18 +251,11 @@ public class XMLDocument
 		}
 
 		private boolean isLocationInfoAware = false;
-		private boolean isNamespaceAware = false;
 		private int prettyPrintIndentation = 0;
 
 		public Builder printPrettyWithIndentation( int indentation )
 		{
 			this.prettyPrintIndentation = indentation;
-			return this;
-		}
-
-		public Builder namespaceAware( boolean namespaceAware )
-		{
-			this.isNamespaceAware = namespaceAware;
 			return this;
 		}
 
@@ -329,37 +268,19 @@ public class XMLDocument
 		public XMLDocument build( InputSource inputSource ) throws IOException, SAXException
 		{
 			Document document = parseInputSource( inputSource );
-			return new XMLDocument( document, prettyPrintIndentation, isNamespaceAware );
+			return new XMLDocument( document, prettyPrintIndentation );
 		}
 
 		private Document parseLocationInfoAware( InputSource inputSource, Document document ) throws SAXException, IOException
 		{
-			SAXParser parser;
-			if (isNamespaceAware)
-			{
-				parser = namespaceAwareSAXParser.get();
-			}
-			else
-			{
-				parser = namespaceUnawareSAXParser.get();
-			}
-
+			SAXParser parser = saxParser.get();
 			parser.parse( inputSource, new LocationInfoHandler( document ) );
 			return document;
 		}
 
 		private Document parseInputSource( InputSource inputSource ) throws IOException, SAXException
 		{
-
-			DocumentBuilder builder;
-			if (isNamespaceAware)
-			{
-				builder = namespaceAwareDocumentBuilder.get();
-			}
-			else
-			{
-				builder = namespaceUnawareDocumentBuilder.get();
-			}
+			DocumentBuilder builder = documentBuilder.get();
 
 			if ( isLocationInfoAware )
 			{
@@ -369,33 +290,6 @@ public class XMLDocument
 			{
 				return builder.parse( inputSource );
 			}
-		}
-	}
-
-	private static class NamespaceContext implements javax.xml.namespace.NamespaceContext
-	{
-		private final Map<String, String> contextMap;
-
-		private NamespaceContext(Map<String, String> contextMap) {
-			this.contextMap = contextMap;
-		}
-
-		@Override
-		public String getNamespaceURI( String prefix )
-		{
-			return contextMap.get( prefix );
-		}
-
-		@Override
-		public String getPrefix( String namespaceURI )
-		{
-			return null;
-		}
-
-		@Override
-		public Iterator<String> getPrefixes( String namespaceURI )
-		{
-			return null;
 		}
 	}
 }

--- a/src/main/resources/cmv-profile-ddi-v32.xml
+++ b/src/main/resources/cmv-profile-ddi-v32.xml
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<pr:DDIProfile 
- xmlns:pr="ddi:ddiprofile:3_2" 
- xmlns:r="ddi:reusable:3_2" 
- xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+<pr:DDIProfile
+ xmlns:pr="ddi:ddiprofile:3_2"
+ xmlns:r="ddi:reusable:3_2"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
  xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd">
   <r:Agency>int.cessda</r:Agency>
   <r:ID>cmv-profile-ddi-v32</r:ID>
   <r:Version>1.0.0</r:Version>
   <pr:XPathVersion>1.0</pr:XPathVersion>
   <pr:DDINamespace>3.2</pr:DDINamespace>
+  <pr:XMLPrefixMap>
+    <pr:XMLPrefix>pr</pr:XMLPrefix>
+    <pr:XMLNamespace>ddi:ddiprofile:3_2</pr:XMLNamespace>
+  </pr:XMLPrefixMap>
   <pr:Used xpath="/pr:DDIProfile/pr:Used/@xpath" isRequired="true" />
   <pr:Used xpath="/pr:DDIProfile/pr:Used/@isRequired" isRequired="true" />
 </pr:DDIProfile>

--- a/src/main/resources/demo-documents/ddi-v25/cdc25_profile.xml
+++ b/src/main/resources/demo-documents/ddi-v25/cdc25_profile.xml
@@ -110,7 +110,7 @@ ________________________________________________________________________________
                 to be used.</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/parTitl" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:parTitl" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -128,7 +128,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/parTitl/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:parTitl/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'parTitl' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -145,7 +145,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/IDNo" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -156,7 +156,7 @@ ________________________________________________________________________________
                 number is optional. PID is mandatory</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/IDNo/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -171,7 +171,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/IDNo/@agency" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo/@agency" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -181,7 +181,7 @@ ________________________________________________________________________________
                 DOI or Handle or URN </r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/holdings/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:holdings/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -197,7 +197,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/holdings/@URI" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:holdings/@URI" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -208,7 +208,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--PRINCIPAL INVESTIGATOR / CREATOR-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/citation/rspStmt/AuthEnty" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -224,7 +224,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/rspStmt/AuthEnty/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -240,7 +240,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/rspStmt/AuthEnty/@affiliation" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty/@affiliation" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -258,7 +258,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--PUBLISHER-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distrbtr" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -269,7 +269,7 @@ ________________________________________________________________________________
             <r:Content>CDC UI Label: Publisher</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distrbtr/@xml:lang" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr/@xml:lang" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -277,7 +277,7 @@ ________________________________________________________________________________
                 to be used.</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distrbtr/@abbr" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr/@abbr" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -295,7 +295,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--YEAR OF PUBLICATION-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distDate" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distDate" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -312,7 +312,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distDate/@date" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distDate/@date" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'distDate' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -333,7 +333,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--SUBJECTS AND KEYWORDS-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/keyword" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -349,7 +349,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/keyword/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'keyword' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -366,7 +366,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/keyword/@vocab" defaultValue="ELSST"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@vocab" defaultValue="ELSST"
         fixedValue="false" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended if 'keyword' element is present</r:Content>
@@ -382,7 +382,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/keyword/@vocabURI" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@vocabURI" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -396,7 +396,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/topcClas" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -414,7 +414,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/topcClas/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'topcClas' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -431,7 +431,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocab"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocab"
         defaultValue="CESSDA Topic Classification" fixedValue="false" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -447,7 +447,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocabURI" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocabURI" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -465,7 +465,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ABSTRACT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/abstract" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:abstract" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -474,7 +474,7 @@ ________________________________________________________________________________
             <r:Content>CDC UI Label: Abstract</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/abstract/@xml:lang" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:abstract/@xml:lang" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -485,7 +485,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--DATA COLLECTION DATE(S)-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/collDate" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -502,7 +502,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@event" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate/@event" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if parent is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -521,7 +521,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@date" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate/@date" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended strongly if 'collDate' element is present.</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -540,7 +540,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--COUNTRY COVERAGE-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/nation" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -556,7 +556,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'nation' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -573,7 +573,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@abbr" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation/@abbr" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -590,7 +590,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ANALYSIS UNIT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -606,7 +606,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'anlyUnit' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -623,7 +623,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -641,7 +641,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocab"
         defaultValue="DDI Analysis Unit" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -656,7 +656,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocabURI"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocabURI"
         isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
@@ -675,7 +675,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--TIME DIMENSION-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -691,7 +691,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'timeMeth' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -708,7 +708,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept" isRequired="false">
         <r:Description>
             <r:Content>Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -726,7 +726,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept/@vocab"
         defaultValue="DDI Time Method" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -741,13 +741,13 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocabURI"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept/@vocabURI"
         isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
             <r:Content>Usage: The Canonical URL of the CV version that is being used e.g.
-                https://vocabularies.cessda.eu/v2/vocabularies/TimeMethod/1.2?languageVersion=en-1.2</r:Content>
+                https://vocabularies.cessda.eu/v2/vocabularies/ddi:timeMethod/1.2?languageVersion=en-1.2</r:Content>
         </r:Description>
         <pr:Instructions>
             <r:Content><![CDATA[
@@ -760,7 +760,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--SAMPLING METHOD / PROCEDURE-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -777,7 +777,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'sampProc' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -794,7 +794,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept" isRequired="false">
         <r:Description>
             <r:Content>Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -812,7 +812,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept/@vocab"
         defaultValue="DDI Sampling Procedure" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -828,7 +828,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocabURI"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept/@vocabURI"
         isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
@@ -847,7 +847,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--DATA COLLECTION METHOD-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -864,7 +864,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'collMode' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -881,7 +881,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept" isRequired="false">
         <r:Description>
             <r:Content>Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -899,7 +899,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept/@vocab"
         defaultValue="DDI Mode of Collection" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -915,7 +915,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocabURI"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept/@vocabURI"
         isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
@@ -934,7 +934,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ACCESS STATEMENT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/restrctn" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:restrctn" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -953,7 +953,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/restrctn/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:restrctn/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'restrctn' is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -973,7 +973,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--FILE DESCRIPTIONS-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/fileDscr/fileTxt/fileName" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -988,7 +988,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/fileDscr/fileTxt/fileName/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>

--- a/src/main/resources/demo-documents/ddi-v25/cdc25_profile.xml
+++ b/src/main/resources/demo-documents/ddi-v25/cdc25_profile.xml
@@ -66,7 +66,7 @@ ________________________________________________________________________________
             <r:Content>ElementType: Content element</r:Content>
             <r:Content>ElementRepeatable: No</r:Content>
             <r:Content>Usage: Title of the CDC XML document - note that the Study Title goes in
-                /codeBook/stdyDscr/citation/titlStmt/titl</r:Content>
+                /ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl</r:Content>
         </r:Description>
         <pr:Instructions>
             <r:Content><![CDATA[
@@ -76,7 +76,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/docDscr/citation/titlStmt/titl/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:docDscr/ddi:citation/ddi:titlStmt/ddi:titl/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'titl' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -92,7 +92,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-     <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/titl" isRequired="true">
+     <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -102,7 +102,7 @@ ________________________________________________________________________________
             <r:Content>CDC UI Label: Study title</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/titl/@xml:lang" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl/@xml:lang" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>

--- a/src/main/resources/demo-documents/ddi-v25/cdc25_profile.xml
+++ b/src/main/resources/demo-documents/ddi-v25/cdc25_profile.xml
@@ -9,10 +9,10 @@ Change summary from v1.0.3: See https://bitbucket.org/cessda/cessda.metadata.pro
 Last modified 2021-03-01 Darren Bell
 ____________________________________________________________________________________
 -->
-<pr:DDIProfile xmlns:r="ddi:reusable:3_2" xmlns:xhtml="http://www.w3.org/1999/xhtml"
-    xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd"
-    versionDate="2021-03-01">
+<pr:DDIProfile xmlns:r="ddi:reusable:3_2"
+			   xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			   xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd"
+			   versionDate="2021-03-01">
     <r:Agency>CESSDA</r:Agency>
     <r:ID>CDC_DDI25_PROFILE</r:ID>
     <r:Version>1.0.4</r:Version>
@@ -23,7 +23,7 @@ ________________________________________________________________________________
     <pr:XPathVersion>1.0</pr:XPathVersion>
     <pr:DDINamespace>2.5</pr:DDINamespace>
     <pr:XMLPrefixMap>
-        <pr:XMLPrefix/>
+		<pr:XMLPrefix>ddi</pr:XMLPrefix>
         <pr:XMLNamespace>ddi:codebook:2_5</pr:XMLNamespace>
     </pr:XMLPrefixMap>
     <pr:XMLPrefixMap>
@@ -33,7 +33,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ROOT ELEMENT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/@xml:lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/@xml:lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -47,7 +47,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/@xsi:schemaLocation"
+    <pr:Used xpath="/ddi:codeBook/@xsi:schemaLocation"
         defaultValue="ddi:codebook:2_5 http://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd"
         fixedValue="true" isRequired="true">
         <r:Description>
@@ -60,7 +60,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--TITLE AND IDENTIFIERS-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/docDscr/citation/titlStmt/titl" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:docDscr/ddi:citation/ddi:titlStmt/ddi:titl" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -150,8 +150,8 @@ ________________________________________________________________________________
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
             <r:Content>ElementRepeatable: Yes</r:Content>
-            <r:Content>Usage: The content of this element serves two purposes. 
-                It is used both for the PID and for the study/archival number given by the SP. 
+            <r:Content>Usage: The content of this element serves two purposes.
+                It is used both for the PID and for the study/archival number given by the SP.
                 These two cases have different specifications. IDNo in the sense of study
                 number is optional. PID is mandatory</r:Content>
         </r:Description>
@@ -229,7 +229,7 @@ ________________________________________________________________________________
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
             <r:Content>Usage: Language of the Organisation name, which may be the contents of
-                the AuthEnty element or the @affiliation attribute of AuthEnty specifies a person. 
+                the AuthEnty element or the @affiliation attribute of AuthEnty specifies a person.
                 ISO 639-1 codes codes are strongly encouraged to be used.</r:Content>
         </r:Description>
         <pr:Instructions>

--- a/src/main/resources/demo-documents/ddi-v25/cdc25_profile_mono.xml
+++ b/src/main/resources/demo-documents/ddi-v25/cdc25_profile_mono.xml
@@ -33,14 +33,14 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ROOT ELEMENT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/@xml:lang" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/@xml:lang" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
             <r:Content>Usage: ISO 639-1 codes are strongly encouraged to be used</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/@xsi:schemaLocation"
+    <pr:Used xpath="/ddi:codeBook/@xsi:schemaLocation"
         defaultValue="ddi:codebook:2_5 http://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd"
         fixedValue="true" isRequired="true">
         <r:Description>
@@ -53,13 +53,13 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--TITLE AND IDENTIFIERS-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/docDscr/citation/titlStmt/titl" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:docDscr/ddi:citation/ddi:titlStmt/ddi:titl" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
             <r:Content>ElementRepeatable: No</r:Content>
             <r:Content>Usage: Title of the CDC XML document - note that the Study Title goes in
-                /codeBook/stdyDscr/citation/titlStmt/titl</r:Content>
+                /ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl</r:Content>
         </r:Description>
         <pr:Instructions>
             <r:Content><![CDATA[
@@ -69,7 +69,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-     <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/titl" isRequired="true">
+     <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -79,7 +79,7 @@ ________________________________________________________________________________
             <r:Content>CDC UI Label: Study title</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/parTitl" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/parTitl" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -97,7 +97,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/IDNo" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -108,7 +108,7 @@ ________________________________________________________________________________
                 number is optional. PID is mandatory</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/IDNo/@agency" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo/@agency" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -118,7 +118,7 @@ ________________________________________________________________________________
                 DOI or Handle or URN </r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/holdings/@URI" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:holdings/@URI" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -129,7 +129,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--PRINCIPAL INVESTIGATOR / CREATOR-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/citation/rspStmt/AuthEnty" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -145,7 +145,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/rspStmt/AuthEnty/@affiliation" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty/@affiliation" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -163,7 +163,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--PUBLISHER-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distrbtr" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -174,7 +174,7 @@ ________________________________________________________________________________
             <r:Content>CDC UI Label: Publisher</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distrbtr/@abbr" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr/@abbr" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -192,7 +192,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--YEAR OF PUBLICATION-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distDate" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distDate" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -209,7 +209,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distDate/@date" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distDate/@date" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'distDate' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -230,7 +230,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--SUBJECTS AND KEYWORDS-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/keyword" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -246,7 +246,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/keyword/@vocab" defaultValue="ELSST"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@vocab" defaultValue="ELSST"
         fixedValue="false" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended if 'keyword' element is present</r:Content>
@@ -262,7 +262,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/keyword/@vocabURI" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@vocabURI" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -276,7 +276,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/topcClas" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -294,7 +294,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocab"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocab"
         defaultValue="CESSDA Topic Classification" fixedValue="false" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -310,7 +310,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocabURI" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocabURI" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -328,7 +328,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ABSTRACT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/abstract" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:abstract" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -340,7 +340,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--DATA COLLECTION DATE(S)-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/collDate" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -357,7 +357,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@event" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate/@event" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if parent is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -376,7 +376,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@date" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate/@date" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended strongly if 'collDate' element is present.</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -395,7 +395,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--COUNTRY COVERAGE-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/nation" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -411,7 +411,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@abbr" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation/@abbr" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -428,7 +428,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ANALYSIS UNIT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -444,7 +444,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -462,7 +462,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocab"
         defaultValue="DDI Analysis Unit" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -477,7 +477,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocabURI"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocabURI"
         isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
@@ -496,7 +496,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--TIME DIMENSION-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -512,7 +512,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept" isRequired="false">
         <r:Description>
             <r:Content>Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -530,7 +530,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept/@vocab"
         defaultValue="DDI Time Method" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -545,13 +545,13 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocabURI"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept/@vocabURI"
         isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
             <r:Content>Usage: The Canonical URL of the CV version that is being used e.g.
-                https://vocabularies.cessda.eu/v2/vocabularies/TimeMethod/1.2?languageVersion=en-1.2</r:Content>
+                https://vocabularies.cessda.eu/v2/vocabularies/ddi:timeMethod/1.2?languageVersion=en-1.2</r:Content>
         </r:Description>
         <pr:Instructions>
             <r:Content><![CDATA[
@@ -564,7 +564,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--SAMPLING METHOD / PROCEDURE-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -581,7 +581,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept" isRequired="false">
         <r:Description>
             <r:Content>Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -599,7 +599,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept/@vocab"
         defaultValue="DDI Sampling Procedure" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -615,7 +615,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocabURI"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept/@vocabURI"
         isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
@@ -634,7 +634,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--DATA COLLECTION METHOD-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -651,7 +651,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept" isRequired="false">
         <r:Description>
             <r:Content>Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -669,7 +669,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept/@vocab"
         defaultValue="DDI Mode of Collection" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -685,7 +685,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocabURI"
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept/@vocabURI"
         isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
@@ -704,7 +704,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ACCESS STATEMENT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/restrctn" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:restrctn" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -726,7 +726,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--FILE DESCRIPTIONS-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/fileDscr/fileTxt/fileName" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>

--- a/src/main/resources/demo-documents/ddi-v25/cdc25_profile_mono.xml
+++ b/src/main/resources/demo-documents/ddi-v25/cdc25_profile_mono.xml
@@ -9,10 +9,10 @@ Change summary from v1.0.3: See https://bitbucket.org/cessda/cessda.metadata.pro
 Last modified 2021-03-01 Darren Bell
 ____________________________________________________________________________________
 -->
-<pr:DDIProfile xmlns:r="ddi:reusable:3_2" xmlns:xhtml="http://www.w3.org/1999/xhtml"
-    xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd"
-    versionDate="2021-03-01">
+<pr:DDIProfile xmlns:r="ddi:reusable:3_2"
+			   xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			   xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd"
+			   versionDate="2021-03-01">
     <r:Agency>CESSDA</r:Agency>
     <r:ID>CDC_DDI25_PROFILE_MONOLINGUAL</r:ID>
     <r:Version>1.0.4</r:Version>
@@ -23,7 +23,7 @@ ________________________________________________________________________________
     <pr:XPathVersion>1.0</pr:XPathVersion>
     <pr:DDINamespace>2.5</pr:DDINamespace>
     <pr:XMLPrefixMap>
-        <pr:XMLPrefix/>
+		<pr:XMLPrefix>ddi</pr:XMLPrefix>
         <pr:XMLNamespace>ddi:codebook:2_5</pr:XMLNamespace>
     </pr:XMLPrefixMap>
     <pr:XMLPrefixMap>
@@ -102,8 +102,8 @@ ________________________________________________________________________________
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
             <r:Content>ElementRepeatable: Yes</r:Content>
-            <r:Content>Usage: The content of this element serves two purposes. 
-                It is used both for the PID and for the study/archival number given by the SP. 
+            <r:Content>Usage: The content of this element serves two purposes.
+                It is used both for the PID and for the study/archival number given by the SP.
                 These two cases have different specifications. IDNo in the sense of study
                 number is optional. PID is mandatory</r:Content>
         </r:Description>

--- a/src/main/resources/demo-documents/ddi-v25/cdc_122_profile.xml
+++ b/src/main/resources/demo-documents/ddi-v25/cdc_122_profile.xml
@@ -9,10 +9,10 @@ Change summary from v1.0.3: See https://bitbucket.org/cessda/cessda.metadata.pro
 Last modified 2021-03-01 Darren Bell
 ____________________________________________________________________________________
 -->
-<pr:DDIProfile xmlns:r="ddi:reusable:3_2" xmlns:xhtml="http://www.w3.org/1999/xhtml"
-    xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd"
-    versionDate="2021-03-01">
+<pr:DDIProfile xmlns:r="ddi:reusable:3_2"
+			   xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			   xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd"
+			   versionDate="2021-03-01">
     <r:Agency>CESSDA</r:Agency>
     <r:ID>CDC_DDI122_PROFILE</r:ID>
     <r:Version>1.0.4</r:Version>
@@ -24,7 +24,7 @@ ________________________________________________________________________________
     <pr:DDINamespace>1.22</pr:DDINamespace>
     <!--NOTE THAT DDIPROFILE.XSD DOES NOT PERMIT FORMAT OF "1.2.2" IN THIS ELEMENT-->
     <pr:XMLPrefixMap>
-        <pr:XMLPrefix/>
+		<pr:XMLPrefix>ddi</pr:XMLPrefix>
         <pr:XMLNamespace>http://www.icpsr.umich.edu/DDI</pr:XMLNamespace>
     </pr:XMLPrefixMap>
     <pr:XMLPrefixMap>
@@ -34,7 +34,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ROOT ELEMENT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -48,7 +48,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/@xsi:schemaLocation"
+    <pr:Used xpath="/ddi:codeBook/@xsi:schemaLocation"
         defaultValue="http://www.icpsr.umich.edu/DDI http://www.icpsr.umich.edu/DDI/Version1-2-2.xsd"
         fixedValue="true" isRequired="true">
         <r:Description>
@@ -61,13 +61,13 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--TITLE AND IDENTIFIERS-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/docDscr/citation/titlStmt/titl" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/docDscr/citation/titlStmt/titl" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
             <r:Content>ElementRepeatable: No</r:Content>
             <r:Content>Usage: Title of the CDC XML document - note that the Study Title goes in
-                /codeBook/stdyDscr/citation/titlStmt/titl</r:Content>
+                /ddi:codeBook/stdyDscr/citation/titlStmt/titl</r:Content>
         </r:Description>
         <pr:Instructions>
             <r:Content><![CDATA[
@@ -77,7 +77,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/docDscr/citation/titlStmt/titl/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/docDscr/citation/titlStmt/titl/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'titl' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -93,7 +93,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-        <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/titl" isRequired="true">
+        <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/titlStmt/titl" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -103,14 +103,14 @@ ________________________________________________________________________________
             <r:Content>CDC UI Label: Study title</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/titl/@xml-lang" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/titlStmt/titl/@xml-lang" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
             <r:Content>Usage: Language of the study title. ISO 639-1 codes are strongly encouraged to be used.</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/parTitl" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/titlStmt/parTitl" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -128,7 +128,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/parTitl/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/titlStmt/parTitl/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'parTitl' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -144,18 +144,18 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/IDNo" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/titlStmt/IDNo" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
             <r:Content>ElementRepeatable: Yes</r:Content>
-            <r:Content>Usage: The content of this element serves two purposes. 
-                It is used both for the PID and for the study/archival number given by the SP. 
+            <r:Content>Usage: The content of this element serves two purposes.
+                It is used both for the PID and for the study/archival number given by the SP.
                 These two cases have different specifications. IDNo in the sense of study
                 number is optional. PID is mandatory</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/IDNo/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/titlStmt/IDNo/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -170,17 +170,17 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/IDNo/@agency" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/titlStmt/IDNo/@agency" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
-            <r:Content>Usage: Agency responsible for the identifier of the study. If you are using IDNo for a 
+            <r:Content>Usage: Agency responsible for the identifier of the study. If you are using IDNo for a
                 Persistent Identifer, value should be one of https://vocabularies.cessda.eu/vocabulary/CessdaPersistentIdentifierTypes i.e.
                 ARK or DOI or Handle or URN
             </r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/holdings/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/holdings/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -196,7 +196,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/holdings/@URI" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/holdings/@URI" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -207,7 +207,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--PRINCIPAL INVESTIGATOR / CREATOR-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/citation/rspStmt/AuthEnty" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/rspStmt/AuthEnty" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -223,12 +223,12 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/rspStmt/AuthEnty/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/rspStmt/AuthEnty/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
             <r:Content>Usage: Language of the Organisation name, which may be the contents of
-                the AuthEnty element or the @affiliation attribute of AuthEnty specifies a person. 
+                the AuthEnty element or the @affiliation attribute of AuthEnty specifies a person.
                 ISO 639-1 codes codes are strongly encouraged to be used.</r:Content>
         </r:Description>
         <pr:Instructions>
@@ -239,7 +239,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/rspStmt/AuthEnty/@affiliation" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/rspStmt/AuthEnty/@affiliation" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -257,7 +257,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--PUBLISHER-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distrbtr" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/distStmt/distrbtr" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -268,7 +268,7 @@ ________________________________________________________________________________
             <r:Content>CDC UI Label: Publisher</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distrbtr/@xml-lang" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/distStmt/distrbtr/@xml-lang" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -276,7 +276,7 @@ ________________________________________________________________________________
                 used.</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distrbtr/@abbr" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/distStmt/distrbtr/@abbr" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -294,12 +294,12 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--YEAR OF PUBLICATION-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distDate" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/distStmt/distDate" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
             <r:Content>ElementRepeatable: Yes</r:Content>
-            <r:Content>Usage: The year or freetext date of when the study description was published.  
+            <r:Content>Usage: The year or freetext date of when the study description was published.
                 This element may be empty.</r:Content>
             <r:Content>CDC UI Label: Year of publication</r:Content>
         </r:Description>
@@ -311,7 +311,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distDate/@date" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/distStmt/distDate/@date" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'distDate' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -332,7 +332,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--SUBJECTS AND KEYWORDS-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/keyword" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/subject/keyword" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -348,7 +348,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/keyword/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/subject/keyword/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'keyword' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -364,7 +364,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/keyword/@vocab" defaultValue="ELSST"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/subject/keyword/@vocab" defaultValue="ELSST"
         fixedValue="false" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended if 'keyword' element is present</r:Content>
@@ -380,7 +380,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/keyword/@vocabURI" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/subject/keyword/@vocabURI" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -394,7 +394,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/topcClas" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/subject/topcClas" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -412,7 +412,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/topcClas/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/subject/topcClas/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'topcClas' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -429,7 +429,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocab"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocab"
         defaultValue="CESSDA Topic Classification" fixedValue="false" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -445,7 +445,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocabURI" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocabURI" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -463,7 +463,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ABSTRACT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/abstract" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/abstract" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -472,7 +472,7 @@ ________________________________________________________________________________
             <r:Content>CDC UI Label: Abstract</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/abstract/@xml-lang" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/abstract/@xml-lang" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -482,12 +482,12 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--DATA COLLECTION DATE(S)-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/collDate" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/collDate" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
             <r:Content>ElementRepeatable: Yes</r:Content>
-            <r:Content>Usage: This is the free text expression of the collection period. 
+            <r:Content>Usage: This is the free text expression of the collection period.
                 This element may be empty.</r:Content>
             <r:Content>CDC UI Label: Data collection period</r:Content>
         </r:Description>
@@ -499,7 +499,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@event" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@event" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if parent is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -518,7 +518,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@date" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@date" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended strongly if 'collDate' element is present.</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -537,7 +537,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--COUNTRY COVERAGE-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/nation" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/nation" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -553,7 +553,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/nation/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'nation' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -570,7 +570,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@abbr" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/nation/@abbr" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -587,7 +587,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ANALYSIS UNIT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -603,7 +603,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'anlyUnit' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -620,7 +620,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -637,7 +637,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab"
         defaultValue="DDI Analysis Unit" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -652,7 +652,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocabURI"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocabURI"
         isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
@@ -671,7 +671,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--TIME DIMENSION-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/timeMeth" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -687,7 +687,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/timeMeth/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'timeMeth' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -704,14 +704,14 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/timeMeth/concept" isRequired="false">
         <r:Description>
             <r:Content>Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
             <r:Content>ElementRepeatable: No</r:Content>
             <r:Content>Usage: Time Method Controlled Vocabulary "Code value" that is the same across
                 languages. e.g if the 'timeMeth' element is 'Pitkittäisaineisto' for Finnish, the
-                'concept' element is 'Longitudinal'. See example at 
+                'concept' element is 'Longitudinal'. See example at
                 https://vocabularies.cessda.eu/urn/urn:ddi:int.ddi.cv:TimeMethod</r:Content>
         </r:Description>
         <pr:Instructions>
@@ -722,7 +722,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocab"
         defaultValue="DDI Time Method" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -737,7 +737,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocabURI" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocabURI" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -755,7 +755,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--SAMPLING METHOD / PROCEDURE-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/sampProc" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -772,7 +772,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/sampProc/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'sampProc' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -789,7 +789,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/sampProc/concept" isRequired="false">
         <r:Description>
             <r:Content>Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -806,7 +806,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocab"
         defaultValue="DDI Sampling Procedure" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -822,7 +822,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocabURI"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocabURI"
         isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
@@ -841,7 +841,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--DATA COLLECTION METHOD-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/collMode" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -858,7 +858,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/collMode/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'collMode' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -875,7 +875,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/collMode/concept" isRequired="false">
         <r:Description>
             <r:Content>Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -892,7 +892,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/collMode/concept/@vocab"
         defaultValue="DDI Mode of Collection" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -908,7 +908,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocabURI"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/collMode/concept/@vocabURI"
         isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
@@ -927,7 +927,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ACCESS STATEMENT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/restrctn" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/dataAccs/useStmt/restrctn" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -946,7 +946,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/restrctn/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/dataAccs/useStmt/restrctn/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'restrctn' is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -966,7 +966,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--FILE DESCRIPTIONS-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/fileDscr/fileTxt/fileName" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/fileDscr/fileTxt/fileName" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -981,7 +981,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/fileDscr/fileTxt/fileName/@xml-lang" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/fileDscr/fileTxt/fileName/@xml-lang" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>

--- a/src/main/resources/demo-documents/ddi-v25/cdc_122_profile_mono.xml
+++ b/src/main/resources/demo-documents/ddi-v25/cdc_122_profile_mono.xml
@@ -10,10 +10,10 @@ Change summary from v1.0.3: See https://bitbucket.org/cessda/cessda.metadata.pro
 Last modified 2021-03-01 Darren Bell
 ____________________________________________________________________________________
 -->
-<pr:DDIProfile xmlns:r="ddi:reusable:3_2" xmlns:xhtml="http://www.w3.org/1999/xhtml"
-    xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd"
-    versionDate="2021-03-01">
+<pr:DDIProfile xmlns:r="ddi:reusable:3_2"
+			   xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			   xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd"
+			   versionDate="2021-03-01">
     <r:Agency>CESSDA</r:Agency>
     <r:ID>CDC_DDI122_PROFILE_MONOLINGUAL</r:ID>
     <r:Version>1.0.4</r:Version>
@@ -25,7 +25,7 @@ ________________________________________________________________________________
     <pr:DDINamespace>1.22</pr:DDINamespace>
     <!--NOTE THAT DDIPROFILE.XSD DOES NOT PERMIT FORMAT OF "1.2.2" IN THIS ELEMENT-->
     <pr:XMLPrefixMap>
-        <pr:XMLPrefix/>
+		<pr:XMLPrefix>ddi</pr:XMLPrefix>
         <pr:XMLNamespace>http://www.icpsr.umich.edu/DDI</pr:XMLNamespace>
     </pr:XMLPrefixMap>
     <pr:XMLPrefixMap>
@@ -35,14 +35,14 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ROOT ELEMENT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/@xml-lang" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/@xml-lang" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
             <r:Content>Usage: ISO 639-1 codes are strongly encouraged to be used</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/@xsi:schemaLocation"
+    <pr:Used xpath="/ddi:codeBook/@xsi:schemaLocation"
         defaultValue="http://www.icpsr.umich.edu/DDI http://www.icpsr.umich.edu/DDI/Version1-2-2.xsd"
         fixedValue="true" isRequired="true">
         <r:Description>
@@ -55,13 +55,13 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--TITLE AND IDENTIFIERS-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/docDscr/citation/titlStmt/titl" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/docDscr/citation/titlStmt/titl" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
             <r:Content>ElementRepeatable: No</r:Content>
             <r:Content>Usage: Title of the CDC XML document - note that the Study Title goes in
-                /codeBook/stdyDscr/citation/titlStmt/titl</r:Content>
+                /ddi:codeBook/stdyDscr/citation/titlStmt/titl</r:Content>
         </r:Description>
         <pr:Instructions>
             <r:Content><![CDATA[
@@ -71,7 +71,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-        <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/titl" isRequired="true">
+        <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/titlStmt/titl" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -81,7 +81,7 @@ ________________________________________________________________________________
             <r:Content>CDC UI Label: Study title</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/parTitl" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/titlStmt/parTitl" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -99,28 +99,28 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/IDNo" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/titlStmt/IDNo" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
             <r:Content>ElementRepeatable: Yes</r:Content>
-            <r:Content>Usage: The content of this element serves two purposes. 
-                It is used both for the PID and for the study/archival number given by the SP. 
+            <r:Content>Usage: The content of this element serves two purposes.
+                It is used both for the PID and for the study/archival number given by the SP.
                 These two cases have different specifications. IDNo in the sense of study
                 number is optional. PID is mandatory</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/IDNo/@agency" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/titlStmt/IDNo/@agency" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
-            <r:Content>Usage: Agency responsible for the identifier of the study. If you are using IDNo for a 
+            <r:Content>Usage: Agency responsible for the identifier of the study. If you are using IDNo for a
                 Persistent Identifer, value should be one of https://vocabularies.cessda.eu/vocabulary/CessdaPersistentIdentifierTypes i.e.
                 ARK or DOI or Handle or URN
             </r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/holdings/@URI" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/holdings/@URI" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -131,7 +131,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--PRINCIPAL INVESTIGATOR / CREATOR-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/citation/rspStmt/AuthEnty" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/rspStmt/AuthEnty" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -147,7 +147,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/rspStmt/AuthEnty/@affiliation" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/rspStmt/AuthEnty/@affiliation" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -165,7 +165,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--PUBLISHER-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distrbtr" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/distStmt/distrbtr" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -176,7 +176,7 @@ ________________________________________________________________________________
             <r:Content>CDC UI Label: Publisher</r:Content>
         </r:Description>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distrbtr/@abbr" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/distStmt/distrbtr/@abbr" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -194,12 +194,12 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--YEAR OF PUBLICATION-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distDate" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/distStmt/distDate" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
             <r:Content>ElementRepeatable: Yes</r:Content>
-            <r:Content>Usage: The year or freetext date of when the study description was published.  
+            <r:Content>Usage: The year or freetext date of when the study description was published.
                 This element may be empty.</r:Content>
             <r:Content>CDC UI Label: Year of publication</r:Content>
         </r:Description>
@@ -211,7 +211,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/distStmt/distDate/@date" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/citation/distStmt/distDate/@date" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if 'distDate' element is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -232,7 +232,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--SUBJECTS AND KEYWORDS-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/keyword" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/subject/keyword" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -248,7 +248,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/keyword/@vocab" defaultValue="ELSST"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/subject/keyword/@vocab" defaultValue="ELSST"
         fixedValue="false" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended if 'keyword' element is present</r:Content>
@@ -264,7 +264,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/keyword/@vocabURI" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/subject/keyword/@vocabURI" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -278,7 +278,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/topcClas" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/subject/topcClas" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -296,7 +296,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocab"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocab"
         defaultValue="CESSDA Topic Classification" fixedValue="false" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -312,7 +312,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocabURI" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocabURI" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -330,7 +330,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ABSTRACT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/abstract" isRequired="true">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/abstract" isRequired="true">
         <r:Description>
             <r:Content>Required: Mandatory</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -342,12 +342,12 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--DATA COLLECTION DATE(S)-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/collDate" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/collDate" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
             <r:Content>ElementRepeatable: Yes</r:Content>
-            <r:Content>Usage: This is the free text expression of the collection period. 
+            <r:Content>Usage: This is the free text expression of the collection period.
                 This element may be empty.</r:Content>
             <r:Content>CDC UI Label: Data collection period</r:Content>
         </r:Description>
@@ -359,7 +359,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@event" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@event" isRequired="false">
         <r:Description>
             <r:Content>Required: Mandatory if parent is present</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -378,7 +378,7 @@ ________________________________________________________________________________
             </r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@date" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@date" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended strongly if 'collDate' element is present.</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -397,7 +397,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--COUNTRY COVERAGE-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/nation" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/nation" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -413,7 +413,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@abbr" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/nation/@abbr" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -430,7 +430,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ANALYSIS UNIT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -446,7 +446,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -463,7 +463,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab"
         defaultValue="DDI Analysis Unit" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -478,7 +478,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocabURI"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocabURI"
         isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
@@ -497,7 +497,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--TIME DIMENSION-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/timeMeth" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -513,14 +513,14 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/timeMeth/concept" isRequired="false">
         <r:Description>
             <r:Content>Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
             <r:Content>ElementRepeatable: No</r:Content>
             <r:Content>Usage: Time Method Controlled Vocabulary "Code value" that is the same across
                 languages. e.g if the 'timeMeth' element is 'Pitkittäisaineisto' for Finnish, the
-                'concept' element is 'Longitudinal'. See example at 
+                'concept' element is 'Longitudinal'. See example at
                 https://vocabularies.cessda.eu/urn/urn:ddi:int.ddi.cv:TimeMethod</r:Content>
         </r:Description>
         <pr:Instructions>
@@ -531,7 +531,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocab"
         defaultValue="DDI Time Method" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -546,7 +546,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocabURI" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocabURI" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
@@ -564,7 +564,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--SAMPLING METHOD / PROCEDURE-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/sampProc" isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -581,7 +581,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/sampProc/concept" isRequired="false">
         <r:Description>
             <r:Content>Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -598,7 +598,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocab"
         defaultValue="DDI Sampling Procedure" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -614,12 +614,12 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocabURI"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocabURI"
         isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
             <r:Content>ElementType: Attribute</r:Content>
-            <r:Content>Usage: The Canonical URL of the CV version that is being used e.g. 
+            <r:Content>Usage: The Canonical URL of the CV version that is being used e.g.
                 https://vocabularies.cessda.eu/v2/vocabularies/SamplingProcedure/1.1?languageVersion=en-1.1</r:Content>
         </r:Description>
         <pr:Instructions>
@@ -633,7 +633,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--DATA COLLECTION METHOD-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/collMode" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -650,7 +650,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode/concept" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/collMode/concept" isRequired="false">
         <r:Description>
             <r:Content>Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -667,7 +667,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocab"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/collMode/concept/@vocab"
         defaultValue="DDI Mode of Collection" fixedValue="true" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
@@ -683,7 +683,7 @@ ________________________________________________________________________________
 			]]></r:Content>
         </pr:Instructions>
     </pr:Used>
-    <pr:Used xpath="/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocabURI"
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/method/dataColl/collMode/concept/@vocabURI"
         isRequired="false">
         <r:Description>
             <r:Content>Required: Optional</r:Content>
@@ -702,7 +702,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--ACCESS STATEMENT-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/restrctn" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/stdyDscr/dataAccs/useStmt/restrctn" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>
@@ -724,7 +724,7 @@ ________________________________________________________________________________
     <!--****************************************************************************************-->
     <!--FILE DESCRIPTIONS-->
     <!--****************************************************************************************-->
-    <pr:Used xpath="/codeBook/fileDscr/fileTxt/fileName" isRequired="false">
+    <pr:Used xpath="/ddi:codeBook/fileDscr/fileTxt/fileName" isRequired="false">
         <r:Description>
             <r:Content>Required: Recommended</r:Content>
             <r:Content>ElementType: Content element</r:Content>

--- a/src/test/java/eu/cessda/cmv/core/CodeValueOfControlledVocabularyConstraintTest.java
+++ b/src/test/java/eu/cessda/cmv/core/CodeValueOfControlledVocabularyConstraintTest.java
@@ -67,7 +67,7 @@ class CodeValueOfControlledVocabularyConstraintTest
 		// then
 		assertThat( constraintViolations, hasSize( 1 ) );
 		assertThat( constraintViolations.get( 0 ).toString(),
-				equalTo( "Code value 'Person' in '/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept' is not element of the controlled vocabulary in 'https://vocabularies.cessda.eu/v2/vocabularies/AnalysisUnit/2.0?languageVersion=en-2.0' (lineNumber: 16, columnNumber: 113)" ) );
+				equalTo( "Code value 'Person' in '/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept' is not element of the controlled vocabulary in 'https://vocabularies.cessda.eu/v2/vocabularies/AnalysisUnit/2.0?languageVersion=en-2.0' (lineNumber: 16, columnNumber: 113)" ) );
 	}
 
 	@Test
@@ -83,7 +83,7 @@ class CodeValueOfControlledVocabularyConstraintTest
 		// then
 		assertThat( constraintViolations, hasSize( 1 ) );
 		assertThat( constraintViolations.get( 0 ).toString(),
-				equalTo( "Code value 'Family.HouseholdFamily' in '/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept' cannot be validated because no controlled vocabulary is declared (lineNumber: 28, columnNumber: 30)" ) );
+				equalTo( "Code value 'Family.HouseholdFamily' in '/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept' cannot be validated because no controlled vocabulary is declared (lineNumber: 28, columnNumber: 30)" ) );
 	}
 
 	@Test

--- a/src/test/java/eu/cessda/cmv/core/DescriptiveTermOfControlledVocabularyConstraintTest.java
+++ b/src/test/java/eu/cessda/cmv/core/DescriptiveTermOfControlledVocabularyConstraintTest.java
@@ -66,7 +66,7 @@ class DescriptiveTermOfControlledVocabularyConstraintTest
 		List<ConstraintViolation> constraintViolations = validationGate.validate( document, profile );
 
 		// then
-		assertThat( constraintViolations, hasSize( 0 ) );
+		assertThat( "Unexpected constraint violations: " + constraintViolations.toString(), constraintViolations, hasSize( 0 ) );
 	}
 
 	@Test
@@ -82,7 +82,7 @@ class DescriptiveTermOfControlledVocabularyConstraintTest
 		// then
 		assertThat( constraintViolations, hasSize( 1 ) );
 		assertThat( constraintViolations.get( 0 ).toString(),
-				equalTo( "Descriptive term 'Family.HouseholdFamily' in '/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit' is not element of the controlled vocabulary in 'https://vocabularies.cessda.eu/v2/vocabularies/AnalysisUnit/2.0?languageVersion=en-2.0' (lineNumber: 28, columnNumber: 27)" ) );
+				equalTo( "Descriptive term 'Family.HouseholdFamily' in '/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit' is not element of the controlled vocabulary in 'https://vocabularies.cessda.eu/v2/vocabularies/AnalysisUnit/2.0?languageVersion=en-2.0' (lineNumber: 28, columnNumber: 27)" ) );
 	}
 
 	@Test

--- a/src/test/java/eu/cessda/cmv/core/DomProfileTest.java
+++ b/src/test/java/eu/cessda/cmv/core/DomProfileTest.java
@@ -49,7 +49,9 @@ class DomProfileTest
 
 			// should be equal
 			InputSource inputSource = new InputSource( url.toExternalForm() );
-			eu.cessda.cmv.core.Profile expectedProfile = new DomSemiStructuredDdiProfile( XMLDocument.newBuilder().build( inputSource ) );
+			XMLDocument document = XMLDocument.newBuilder().build( inputSource );
+			document.setNamespaceContext( DomSemiStructuredDdiProfile.getProfileNamespaceContext() );
+			eu.cessda.cmv.core.Profile expectedProfile = new DomSemiStructuredDdiProfile( document );
 			assertThat( actualProfile, equalTo( expectedProfile ) );
 		}
 	}

--- a/src/test/java/eu/cessda/cmv/core/DomSemiStructuredDdiProfileTest.java
+++ b/src/test/java/eu/cessda/cmv/core/DomSemiStructuredDdiProfileTest.java
@@ -108,7 +108,9 @@ class DomSemiStructuredDdiProfileTest
 
 		// when
 		InputSource inputSource = new InputSource( sourceUrl.toExternalForm() );
-		DomSemiStructuredDdiProfile profile = new DomSemiStructuredDdiProfile( XMLDocument.newBuilder().build( inputSource ) );
+		XMLDocument document = XMLDocument.newBuilder().build( inputSource );
+		document.setNamespaceContext( DomSemiStructuredDdiProfile.getProfileNamespaceContext() );
+		DomSemiStructuredDdiProfile profile = new DomSemiStructuredDdiProfile( document );
 		Profile jaxbProfile = profile.toJaxbProfile();
 		assertThat( jaxbProfile.getConstraints(), hasSize( 61 + 61 + 27 + 10 + 5 + 24 + 12 ) );
 		jaxbProfile.saveAs( actualFile );

--- a/src/test/java/eu/cessda/cmv/core/FixedValueNodeConstraintTest.java
+++ b/src/test/java/eu/cessda/cmv/core/FixedValueNodeConstraintTest.java
@@ -55,7 +55,7 @@ class FixedValueNodeConstraintTest
 		List<ConstraintViolation> constraintViolations = validationGate.validate( document, profile );
 
 		// then
-		assertThat( constraintViolations, hasSize( 0 ) );
+		assertThat( "Unexpected constraint violations: " + constraintViolations.toString(), constraintViolations, hasSize( 0 ) );
 	}
 
 	@Test
@@ -71,7 +71,7 @@ class FixedValueNodeConstraintTest
 		// then
 		assertThat( constraintViolations, hasSize( 1 ) );
 		assertThat( constraintViolations.get( 0 ).toString(),
-				equalTo( "'DDI Analyseeinheit' is not equal to fixed value 'DDI Analysis Unit' in '/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab' (lineNumber: 13, columnNumber: 44)" ) );
+				equalTo( "'DDI Analyseeinheit' is not equal to fixed value 'DDI Analysis Unit' in '/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocab' (lineNumber: 13, columnNumber: 44)" ) );
 	}
 
 	@Test
@@ -87,6 +87,6 @@ class FixedValueNodeConstraintTest
 		// then
 		assertThat( constraintViolations, hasSize( 1 ) );
 		assertThat( constraintViolations.get( 0 ).getMessage(),
-				equalTo( "'/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab' is optional" ) );
+				equalTo( "'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocab' is optional" ) );
 	}
 }

--- a/src/test/java/eu/cessda/cmv/core/mediatype/profile/ProfileTest.java
+++ b/src/test/java/eu/cessda/cmv/core/mediatype/profile/ProfileTest.java
@@ -1,0 +1,136 @@
+package eu.cessda.cmv.core.mediatype.profile;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
+import org.gesis.commons.test.DefaultTestEnv;
+import org.gesis.commons.test.TestEnv;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.transform.stream.StreamSource;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.LOWER_CAMEL_CASE;
+import static com.fasterxml.jackson.databind.PropertyNamingStrategies.UPPER_CAMEL_CASE;
+import static eu.cessda.cmv.core.mediatype.profile.Profile.SCHEMALOCATION_FILENAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.xmlunit.matchers.CompareMatcher.isSimilarTo;
+
+class ProfileTest
+{
+	private final TestEnv.V11 testEnv;
+
+	ProfileTest()
+	{
+		testEnv = DefaultTestEnv.newInstance( ProfileTest.class );
+	}
+
+	private Profile newProfile()
+	{
+		Profile profile = new Profile();
+		profile.setName( "Test Profile" );
+		profile.setVersion( "1.0" );
+
+		FixedValueNodeConstraint fixedValueNodeConstraint = new FixedValueNodeConstraint();
+		fixedValueNodeConstraint.setFixedValue( "Fixed value" );
+		fixedValueNodeConstraint.setLocationPath( "/fixed/value/node/location/path" );
+
+		MandatoryNodeConstraint mandatoryNodeConstraint = new MandatoryNodeConstraint();
+		mandatoryNodeConstraint.setLocationPath( "/mandatory/node/location/path" );
+
+		MandatoryNodeIfParentPresentConstraint mandatoryNodeIfParentPresentConstraint = new MandatoryNodeIfParentPresentConstraint();
+		mandatoryNodeIfParentPresentConstraint.setLocationPath( "/mandatory/node/if/parent/present/location/path" );
+
+		NotBlankNodeConstraint notBlankNodeConstraint = new NotBlankNodeConstraint();
+		notBlankNodeConstraint.setLocationPath( "/not/blank/node/constraint" );
+
+		OptionalNodeConstraint optionalNodeConstraint = new OptionalNodeConstraint();
+		optionalNodeConstraint.setLocationPath( "/optional/node/constraint" );
+
+		PredicatelessXPathConstraint predicatelessXPathConstraint = new PredicatelessXPathConstraint();
+		predicatelessXPathConstraint.setLocationPath( "/predicateless/xpath/node/constraint" );
+
+		RecommendedNodeConstraint recommendedNodeConstraint = new RecommendedNodeConstraint();
+		recommendedNodeConstraint.setLocationPath( "/recommended/node/constraint" );
+
+		profile.setConstraints( Arrays.asList(
+			new CompilableXPathConstraint(),
+			fixedValueNodeConstraint,
+			mandatoryNodeConstraint,
+			mandatoryNodeIfParentPresentConstraint,
+			notBlankNodeConstraint,
+			optionalNodeConstraint,
+			predicatelessXPathConstraint,
+			recommendedNodeConstraint
+		) );
+
+		PrefixMap ddiPrefixMap = new PrefixMap();
+		ddiPrefixMap.setPrefix( "ddi" );
+		ddiPrefixMap.setNamespace( "ddi:codebook:2_5" );
+
+		PrefixMap xsiPrefixMap = new PrefixMap();
+		xsiPrefixMap.setPrefix( "xsi" );
+		xsiPrefixMap.setNamespace( "http://www.w3.org/2001/XMLSchema-instance" );
+
+		profile.setPrefixMap( Arrays.asList( ddiPrefixMap, xsiPrefixMap ) );
+
+		return profile;
+	}
+
+	@Test
+	void writeAndReadWithEclipselinkMoxy()
+	{
+		Profile profile = newProfile();
+
+		File file = new File( testEnv.newDirectory(), "eclipselink-moxy.xml" );
+
+		// Read and write the report to an XML file
+		profile.saveAs( file );
+
+		// Compare the report to the expected XML
+		assertThat( new StreamSource( file ), isSimilarTo( new StreamSource( testEnv.findTestResourceByName( "eclipselink-moxy.xml" ) ) ).ignoreWhitespace() );
+	}
+
+	@Test
+	void writeAndReadWithJackson() throws IOException
+	{
+		writeAndReadWithJackson( new File("jackson.json" ), LOWER_CAMEL_CASE, new ObjectMapper() );
+
+		XmlMapper objectMapper = new XmlMapper();
+		objectMapper.registerModule( new JaxbAnnotationModule() );
+		writeAndReadWithJackson( new File( "jackson.xml" ), UPPER_CAMEL_CASE, objectMapper );
+	}
+
+	private void writeAndReadWithJackson( File file, PropertyNamingStrategy propertyNamingStrategy, ObjectMapper objectMapper ) throws IOException
+	{
+		objectMapper.setPropertyNamingStrategy( propertyNamingStrategy );
+
+		Profile profile = newProfile();
+
+		// Serialise the result to a string
+		String content = objectMapper.writeValueAsString( profile );
+
+		// Parse the string into a JSON tree, and compare with the reference file
+		// Direct string comparisons are unreliable (e.g. line endings, differences in serialisation)
+		JsonNode actualTree = objectMapper.readTree( content );
+		JsonNode expectedTree = objectMapper.readTree( testEnv.findTestResourceByName( file.getName() ) );
+		assertThat( actualTree, equalTo( expectedTree ) );
+	}
+
+	@Test
+	void testGenerateSchema()
+	{
+		File expectedFile = testEnv.findTestResourceByName( SCHEMALOCATION_FILENAME );
+		File actualFile = new File( testEnv.newDirectory(), SCHEMALOCATION_FILENAME );
+
+		Profile.generateSchema( actualFile );
+
+		// Compare the generated file to the expected file
+		assertThat( new StreamSource( actualFile ), isSimilarTo( new StreamSource( expectedFile ) ).ignoreWhitespace() );
+	}
+}

--- a/src/test/resources/eu.cessda.cmv.core.CodeValueOfControlledVocabularyConstraintTest/9-profile.xml
+++ b/src/test/resources/eu.cessda.cmv.core.CodeValueOfControlledVocabularyConstraintTest/9-profile.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<pr:DDIProfile xmlns:r="ddi:reusable:3_2" xmlns:xhtml="http://www.w3.org/1999/xhtml"
-    xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd">
+<pr:DDIProfile xmlns:r="ddi:reusable:3_2"
+			   xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			   xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd">
     <r:Agency>CESSDA</r:Agency>
     <r:ID>PROFILE</r:ID>
     <r:Version>0.1.0</r:Version>
     <pr:XPathVersion>1.0</pr:XPathVersion>
     <pr:DDINamespace>2.5</pr:DDINamespace>
-	<pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept">
+	<pr:XMLPrefixMap>
+		<pr:XMLPrefix>ddi</pr:XMLPrefix>
+		<pr:XMLNamespace>ddi:codebook:2_5</pr:XMLNamespace>
+	</pr:XMLPrefixMap>
+	<pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept">
 	  <pr:Instructions>
 	    <r:Content>
 	      <![CDATA[
@@ -18,7 +22,7 @@
 	    </r:Content>
 	  </pr:Instructions>
 	</pr:Used>
-	<pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocabURI">
+	<pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocabURI">
 	  <pr:Instructions>
 	    <r:Content>
 	      <![CDATA[

--- a/src/test/resources/eu.cessda.cmv.core.DescriptiveTermOfControlledVocabularyConstraintTest/ddi-v25/27-profile.xml
+++ b/src/test/resources/eu.cessda.cmv.core.DescriptiveTermOfControlledVocabularyConstraintTest/ddi-v25/27-profile.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<pr:DDIProfile xmlns:r="ddi:reusable:3_2" xmlns:xhtml="http://www.w3.org/1999/xhtml"
-    xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd">
+<pr:DDIProfile xmlns:r="ddi:reusable:3_2"
+			   xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			   xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd">
 	<r:Agency>int.cessda</r:Agency>
 	<r:ID>ddi-v25-22-profile</r:ID>
 	<r:Version>1</r:Version>
 	<pr:XPathVersion>1.0</pr:XPathVersion>
 	<pr:DDINamespace>2.5</pr:DDINamespace>
-	<pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit">
+	<pr:XMLPrefixMap>
+		<pr:XMLPrefix>ddi</pr:XMLPrefix>
+		<pr:XMLNamespace>ddi:codebook:2_5</pr:XMLNamespace>
+	</pr:XMLPrefixMap>
+	<pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit">
 	  <pr:Instructions>
 	    <r:Content>
 	      <![CDATA[
@@ -18,7 +22,7 @@
 	    </r:Content>
 	  </pr:Instructions>
 	</pr:Used>
-	<pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocabURI">
+	<pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocabURI">
 	  <pr:Instructions>
 	    <r:Content>
 	      <![CDATA[

--- a/src/test/resources/eu.cessda.cmv.core.FixedValueNodeConstraintTest/13-profile.xml
+++ b/src/test/resources/eu.cessda.cmv.core.FixedValueNodeConstraintTest/13-profile.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<pr:DDIProfile xmlns:r="ddi:reusable:3_2" xmlns:xhtml="http://www.w3.org/1999/xhtml"
-    xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd">
+<pr:DDIProfile xmlns:r="ddi:reusable:3_2"
+			   xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			   xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd">
 	<r:Agency>int.cessda</r:Agency>
 	<r:ID>ddi-v25-13-profile</r:ID>
 	<r:Version>1</r:Version>
 	<pr:XPathVersion>1.0</pr:XPathVersion>
 	<pr:DDINamespace>2.5</pr:DDINamespace>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab"
+	<pr:XMLPrefixMap>
+		<pr:XMLPrefix>ddi</pr:XMLPrefix>
+		<pr:XMLNamespace>ddi:codebook:2_5</pr:XMLNamespace>
+	</pr:XMLPrefixMap>
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocab"
         defaultValue="DDI Analysis Unit" fixedValue="true" isRequired="false">
     </pr:Used>
 </pr:DDIProfile>

--- a/src/test/resources/eu.cessda.cmv.core.MandatoryNodeConstraintTest/ddi-v25/10-profile.xml
+++ b/src/test/resources/eu.cessda.cmv.core.MandatoryNodeConstraintTest/ddi-v25/10-profile.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<pr:DDIProfile xmlns:r="ddi:reusable:3_2" xmlns:xhtml="http://www.w3.org/1999/xhtml"
-    xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd">
+<pr:DDIProfile xmlns:r="ddi:reusable:3_2"
+			   xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			   xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd">
     <r:Agency>int.cessda</r:Agency>
     <r:ID>ddi-v25-10-profile</r:ID>
     <r:Version>1</r:Version>
     <pr:XPathVersion>1.0</pr:XPathVersion>
     <pr:DDINamespace>2.5</pr:DDINamespace>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/titl" isRequired="true" />
+	<pr:XMLPrefixMap>
+		<pr:XMLPrefix>ddi</pr:XMLPrefix>
+		<pr:XMLNamespace>ddi:codebook:2_5</pr:XMLNamespace>
+	</pr:XMLPrefixMap>
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl" isRequired="true" />
 </pr:DDIProfile>

--- a/src/test/resources/eu.cessda.cmv.core.MandatoryNodeIfParentPresentConstraintTest/ddi-v25/22-profile.xml
+++ b/src/test/resources/eu.cessda.cmv.core.MandatoryNodeIfParentPresentConstraintTest/ddi-v25/22-profile.xml
@@ -9,8 +9,12 @@
 	<r:Version>1</r:Version>
 	<pr:XPathVersion>1.0</pr:XPathVersion>
 	<pr:DDINamespace>2.5</pr:DDINamespace>
-	<pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/IDNo" isRequired="false"/>
-	<pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/IDNo/@agency" isRequired="false">
+	<pr:XMLPrefixMap>
+		<pr:XMLPrefix>ddi</pr:XMLPrefix>
+		<pr:XMLNamespace>ddi:codebook:2_5</pr:XMLNamespace>
+	</pr:XMLPrefixMap>
+	<pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo" isRequired="false"/>
+	<pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo/@agency" isRequired="false">
 		<pr:Instructions>
 			<r:Content>
 				<![CDATA[

--- a/src/test/resources/eu.cessda.cmv.core.MaximumElementOccurrenceConstraintTest/profile.xml
+++ b/src/test/resources/eu.cessda.cmv.core.MaximumElementOccurrenceConstraintTest/profile.xml
@@ -7,7 +7,11 @@
     <r:Version>0.1.0</r:Version>
     <pr:XPathVersion>1.0</pr:XPathVersion>
     <pr:DDINamespace>2.5</pr:DDINamespace>
-    <pr:Used xpath="/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept" limitMaxOccurs="3" isRequired="true">
+	<pr:XMLPrefixMap>
+		<pr:XMLPrefix>ddi</pr:XMLPrefix>
+		<pr:XMLNamespace>ddi:codebook:2_5</pr:XMLNamespace>
+	</pr:XMLPrefixMap>
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept" limitMaxOccurs="3" isRequired="true">
         <pr:Instructions>
         	<r:Content>
         		<!-- default -->

--- a/src/test/resources/eu.cessda.cmv.core.NotBlankNodeConstraintTest/ddi-v25/57-profile.xml
+++ b/src/test/resources/eu.cessda.cmv.core.NotBlankNodeConstraintTest/ddi-v25/57-profile.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<pr:DDIProfile xmlns:r="ddi:reusable:3_2" xmlns:xhtml="http://www.w3.org/1999/xhtml"
-    xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd">
+<pr:DDIProfile xmlns:r="ddi:reusable:3_2"
+			   xmlns:pr="ddi:ddiprofile:3_2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			   xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd">
     <r:Agency>int.cessda</r:Agency>
     <r:ID>ddi-v25-10-profile</r:ID>
     <r:Version>1</r:Version>
     <pr:XPathVersion>1.0</pr:XPathVersion>
     <pr:DDINamespace>2.5</pr:DDINamespace>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/titl" isRequired="false">
+	<pr:XMLPrefixMap>
+		<pr:XMLPrefix>ddi</pr:XMLPrefix>
+		<pr:XMLNamespace>ddi:codebook:2_5</pr:XMLNamespace>
+	</pr:XMLPrefixMap>
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl" isRequired="false">
       <pr:Instructions>
         <r:Content><![CDATA[
         <Constraints>

--- a/src/test/resources/eu.cessda.cmv.core.OptionalNodeConstraintTest/ddi-v25/12-profile.xml
+++ b/src/test/resources/eu.cessda.cmv.core.OptionalNodeConstraintTest/ddi-v25/12-profile.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <pr:DDIProfile xmlns:r="ddi:reusable:3_2"
-    xmlns:pr="ddi:ddiprofile:3_2" 
+    xmlns:pr="ddi:ddiprofile:3_2"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="ddi:ddiprofile:3_2 https://ddialliance.org/Specification/DDI-Lifecycle/3.2/XMLSchema/ddiprofile.xsd">
 	<r:Agency>int.cessda</r:Agency>
@@ -8,5 +8,9 @@
 	<r:Version>1</r:Version>
     <pr:XPathVersion>1.0</pr:XPathVersion>
     <pr:DDINamespace>2.5</pr:DDINamespace>
-    <pr:Used xpath="/codeBook/stdyDscr/citation/titlStmt/IDNo" isRequired="false" />
+	<pr:XMLPrefixMap>
+		<pr:XMLPrefix>ddi</pr:XMLPrefix>
+		<pr:XMLNamespace>ddi:codebook:2_5</pr:XMLNamespace>
+	</pr:XMLPrefixMap>
+    <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo" isRequired="false" />
 </pr:DDIProfile>

--- a/src/test/resources/eu.cessda.cmv.core.RecommendedNodeConstraintTest/ddi-v25/11-profile.xml
+++ b/src/test/resources/eu.cessda.cmv.core.RecommendedNodeConstraintTest/ddi-v25/11-profile.xml
@@ -4,7 +4,11 @@
   <r:Version>1</r:Version>
   <pr:XPathVersion>1.0</pr:XPathVersion>
   <pr:DDINamespace>2.5</pr:DDINamespace>
-  <pr:Used xpath="/codeBook/stdyDscr/dataAccs/useStmt/restrctn" isRequired="false">
+  <pr:XMLPrefixMap>
+    <pr:XMLPrefix>ddi</pr:XMLPrefix>
+    <pr:XMLNamespace>ddi:codebook:2_5</pr:XMLNamespace>
+  </pr:XMLPrefixMap>
+  <pr:Used xpath="/ddi:codeBook/ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:restrctn" isRequired="false">
     <pr:Instructions>
       <r:Content><![CDATA[
 			<Constraints>

--- a/src/test/resources/eu.cessda.cmv.core.mediatype.profile.ProfileTest/eclipselink-moxy.xml
+++ b/src/test/resources/eu.cessda.cmv.core.mediatype.profile.ProfileTest/eclipselink-moxy.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Profile xsi:schemaLocation="cmv:profile:v0 https://raw.githubusercontent.com/cessda/cessda.cmv.core/stable/schema/profile-v0.2.xsd" xmlns="cmv:profile:v0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<Name>Test Profile</Name>
+	<Version>1.0</Version>
+	<PrefixMaps>
+		<PrefixMap>
+			<Prefix>ddi</Prefix>
+			<Namespace>ddi:codebook:2_5</Namespace>
+		</PrefixMap>
+		<PrefixMap>
+			<Prefix>xsi</Prefix>
+			<Namespace>http://www.w3.org/2001/XMLSchema-instance</Namespace>
+		</PrefixMap>
+	</PrefixMaps>
+	<CompilableXPathConstraint/>
+	<FixedValueNodeConstraint>
+		<LocationPath>/fixed/value/node/location/path</LocationPath>
+		<FixedValue>Fixed value</FixedValue>
+	</FixedValueNodeConstraint>
+	<MandatoryNodeConstraint>
+		<LocationPath>/mandatory/node/location/path</LocationPath>
+	</MandatoryNodeConstraint>
+	<MandatoryNodeIfParentPresentConstraint>
+		<LocationPath>/mandatory/node/if/parent/present/location/path</LocationPath>
+	</MandatoryNodeIfParentPresentConstraint>
+	<NotBlankNodeConstraint>
+		<LocationPath>/not/blank/node/constraint</LocationPath>
+	</NotBlankNodeConstraint>
+	<OptionalNodeConstraint>
+		<LocationPath>/optional/node/constraint</LocationPath>
+	</OptionalNodeConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/predicateless/xpath/node/constraint</LocationPath>
+	</PredicatelessXPathConstraint>
+	<RecommendedNodeConstraint>
+		<LocationPath>/recommended/node/constraint</LocationPath>
+	</RecommendedNodeConstraint>
+</Profile>

--- a/src/test/resources/eu.cessda.cmv.core.mediatype.profile.ProfileTest/jackson.json
+++ b/src/test/resources/eu.cessda.cmv.core.mediatype.profile.ProfileTest/jackson.json
@@ -1,0 +1,41 @@
+{
+	"name": "Test Profile",
+	"version": "1.0",
+	"prefixMaps": [
+		{
+			"prefix": "ddi",
+			"namespace": "ddi:codebook:2_5"
+		},
+		{
+			"prefix": "xsi",
+			"namespace": "http://www.w3.org/2001/XMLSchema-instance"
+		}
+	],
+	"constraints": [
+		{
+			"locationPath": null
+		},
+		{
+			"locationPath": "/fixed/value/node/location/path",
+			"fixedValue": "Fixed value"
+		},
+		{
+			"locationPath": "/mandatory/node/location/path"
+		},
+		{
+			"locationPath": "/mandatory/node/if/parent/present/location/path"
+		},
+		{
+			"locationPath": "/not/blank/node/constraint"
+		},
+		{
+			"locationPath": "/optional/node/constraint"
+		},
+		{
+			"locationPath": "/predicateless/xpath/node/constraint"
+		},
+		{
+			"locationPath": "/recommended/node/constraint"
+		}
+	]
+}

--- a/src/test/resources/eu.cessda.cmv.core.mediatype.profile.ProfileTest/jackson.xml
+++ b/src/test/resources/eu.cessda.cmv.core.mediatype.profile.ProfileTest/jackson.xml
@@ -1,0 +1,57 @@
+<Profile>
+	<Name>Test Profile</Name>
+	<Version>1.0</Version>
+	<Constraints>
+		<Constraints>
+			<CompilableXPathConstraint>
+				<LocationPath/>
+			</CompilableXPathConstraint>
+		</Constraints>
+		<Constraints>
+			<FixedValueNodeConstraint>
+				<LocationPath>/fixed/value/node/location/path</LocationPath>
+				<FixedValue>Fixed value</FixedValue>
+			</FixedValueNodeConstraint>
+		</Constraints>
+		<Constraints>
+			<MandatoryNodeConstraint>
+				<LocationPath>/mandatory/node/location/path</LocationPath>
+			</MandatoryNodeConstraint>
+		</Constraints>
+		<Constraints>
+			<MandatoryNodeIfParentPresentConstraint>
+				<LocationPath>/mandatory/node/if/parent/present/location/path</LocationPath>
+			</MandatoryNodeIfParentPresentConstraint>
+		</Constraints>
+		<Constraints>
+			<NotBlankNodeConstraint>
+				<LocationPath>/not/blank/node/constraint</LocationPath>
+			</NotBlankNodeConstraint>
+		</Constraints>
+		<Constraints>
+			<OptionalNodeConstraint>
+				<LocationPath>/optional/node/constraint</LocationPath>
+			</OptionalNodeConstraint>
+		</Constraints>
+		<Constraints>
+			<PredicatelessXPathConstraint>
+				<LocationPath>/predicateless/xpath/node/constraint</LocationPath>
+			</PredicatelessXPathConstraint>
+		</Constraints>
+		<Constraints>
+			<RecommendedNodeConstraint>
+				<LocationPath>/recommended/node/constraint</LocationPath>
+			</RecommendedNodeConstraint>
+		</Constraints>
+	</Constraints>
+	<PrefixMaps>
+		<PrefixMap>
+			<Prefix>ddi</Prefix>
+			<Namespace>ddi:codebook:2_5</Namespace>
+		</PrefixMap>
+		<PrefixMap>
+			<Prefix>xsi</Prefix>
+			<Namespace>http://www.w3.org/2001/XMLSchema-instance</Namespace>
+		</PrefixMap>
+	</PrefixMaps>
+</Profile>

--- a/src/test/resources/eu.cessda.cmv.core.mediatype.profile.ProfileTest/profile-v0.2.xsd
+++ b/src/test/resources/eu.cessda.cmv.core.mediatype.profile.ProfileTest/profile-v0.2.xsd
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:ns0="cmv:profile:v0" xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="cmv:profile:v0"
+			elementFormDefault="qualified">
+   <xsd:complexType name="ProfileType">
+      <xsd:sequence>
+         <xsd:element name="Name" type="xsd:string" minOccurs="0"/>
+         <xsd:element name="Version" type="xsd:string" minOccurs="0"/>
+         <xsd:element name="PrefixMaps" minOccurs="0">
+            <xsd:complexType>
+               <xsd:sequence>
+                  <xsd:element name="PrefixMap" type="ns0:PrefixMapType" minOccurs="0" maxOccurs="unbounded"/>
+               </xsd:sequence>
+            </xsd:complexType>
+         </xsd:element>
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:element name="CompilableXPathConstraint" type="ns0:CompilableXPathConstraintType" minOccurs="0"/>
+            <xsd:element name="FixedValueNodeConstraint" type="ns0:FixedValueNodeConstraintType" minOccurs="0"/>
+            <xsd:element name="MandatoryNodeConstraint" type="ns0:MandatoryNodeConstraintType" minOccurs="0"/>
+            <xsd:element name="MandatoryNodeIfParentPresentConstraint" type="ns0:MandatoryNodeIfParentPresentConstraintType" minOccurs="0"/>
+            <xsd:element name="MaximumElementOccuranceConstraint" type="ns0:MaximumElementOccuranceConstraintType" minOccurs="0"/>
+            <xsd:element name="NotBlankNodeConstraint" type="ns0:NotBlankNodeConstraintType" minOccurs="0"/>
+            <xsd:element name="OptionalNodeConstraint" type="ns0:OptionalNodeConstraintType" minOccurs="0"/>
+            <xsd:element name="PredicatelessXPathConstraint" type="ns0:PredicatelessXPathConstraintType" minOccurs="0"/>
+            <xsd:element name="RecommendedNodeConstraint" type="ns0:RecommendedNodeConstraintType" minOccurs="0"/>
+         </xsd:choice>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="PrefixMapType">
+      <xsd:sequence>
+         <xsd:element name="Prefix" type="xsd:string" minOccurs="0"/>
+         <xsd:element name="Namespace" type="xsd:string" minOccurs="0"/>
+      </xsd:sequence>
+   </xsd:complexType>
+   <xsd:complexType name="CompilableXPathConstraintType">
+      <xsd:complexContent>
+         <xsd:extension base="ns0:NodeConstraintType">
+            <xsd:sequence/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="NodeConstraintType" abstract="true">
+      <xsd:complexContent>
+         <xsd:extension base="ns0:ConstraintType">
+            <xsd:sequence>
+               <xsd:element name="LocationPath" type="xsd:string" minOccurs="0"/>
+            </xsd:sequence>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="ConstraintType" abstract="true"/>
+   <xsd:complexType name="FixedValueNodeConstraintType">
+      <xsd:complexContent>
+         <xsd:extension base="ns0:NodeConstraintType">
+            <xsd:sequence>
+               <xsd:element name="FixedValue" type="xsd:string" minOccurs="0"/>
+            </xsd:sequence>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="MandatoryNodeConstraintType">
+      <xsd:complexContent>
+         <xsd:extension base="ns0:NodeConstraintType">
+            <xsd:sequence/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="MandatoryNodeIfParentPresentConstraintType">
+      <xsd:complexContent>
+         <xsd:extension base="ns0:NodeConstraintType">
+            <xsd:sequence/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="MaximumElementOccuranceConstraintType">
+      <xsd:complexContent>
+         <xsd:extension base="ns0:NodeConstraintType">
+            <xsd:sequence>
+               <xsd:element name="MaxOccurs" type="xsd:long"/>
+            </xsd:sequence>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="NotBlankNodeConstraintType">
+      <xsd:complexContent>
+         <xsd:extension base="ns0:NodeConstraintType">
+            <xsd:sequence/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="OptionalNodeConstraintType">
+      <xsd:complexContent>
+         <xsd:extension base="ns0:NodeConstraintType">
+            <xsd:sequence/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="PredicatelessXPathConstraintType">
+      <xsd:complexContent>
+         <xsd:extension base="ns0:NodeConstraintType">
+            <xsd:sequence/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:complexType name="RecommendedNodeConstraintType">
+      <xsd:complexContent>
+         <xsd:extension base="ns0:NodeConstraintType">
+            <xsd:sequence/>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+   <xsd:element name="Profile" type="ns0:ProfileType"/>
+</xsd:schema>

--- a/src/test/resources/eu.cessda.cmv.core.mediatype.validationreport.ValidationReportTest/eclipselink-moxy.xml
+++ b/src/test/resources/eu.cessda.cmv.core.mediatype.validationreport.ValidationReportTest/eclipselink-moxy.xml
@@ -4,49 +4,49 @@
 		xsi:schemaLocation="cmv:validation-report:v0 https://raw.githubusercontent.com/cessda/cessda.cmv.core/stable/schema/validation-report-v0.1.xsd" xmlns="cmv:validation-report:v0">
 	<DocumentUri>urn:uuid:00000000-0000-0000-0000-000000000000</DocumentUri>
 	<ConstraintViolation>
-		<Message>'/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocab' is recommended</Message>
+		<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocab' is recommended</Message>
 	</ConstraintViolation>
 	<ConstraintViolation>
-		<Message>'/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocabURI' is recommended</Message>
+		<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocabURI' is recommended</Message>
 	</ConstraintViolation>
 	<ConstraintViolation>
-		<Message>'./@event' is mandatory in /codeBook/stdyDscr/stdyInfo/sumDscr/collDate</Message>
+		<Message>'./@event' is mandatory in /ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate</Message>
 		<LocationInfo>
-         <LineNumber>74</LineNumber>
-         <ColumnNumber>33</ColumnNumber>
-      </LocationInfo>
-   </ConstraintViolation>
-   <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@abbr' is recommended</Message>
-   </ConstraintViolation>
-   <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept' is recommended</Message>
-   </ConstraintViolation>
-   <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab' is recommended</Message>
-   </ConstraintViolation>
-   <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/method/dataColl/timeMeth/concept' is recommended</Message>
-   </ConstraintViolation>
-   <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocab' is recommended</Message>
-   </ConstraintViolation>
-   <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/method/dataColl/sampProc/concept' is recommended</Message>
-   </ConstraintViolation>
-   <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocab' is recommended</Message>
-   </ConstraintViolation>
-   <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/method/dataColl/collMode/concept' is recommended</Message>
-   </ConstraintViolation>
-   <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocab' is recommended</Message>
-   </ConstraintViolation>
-   <ConstraintViolation>
-      <Message>'/codeBook/fileDscr/fileTxt/fileName' is recommended</Message>
-   </ConstraintViolation>
-   <ConstraintViolation>
-      <Message>'/codeBook/fileDscr/fileTxt/fileName/@xml:lang' is recommended</Message>
-   </ConstraintViolation>
+			<LineNumber>74</LineNumber>
+			<ColumnNumber>33</ColumnNumber>
+		</LocationInfo>
+	</ConstraintViolation>
+	<ConstraintViolation>
+		<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation/@abbr' is recommended</Message>
+	</ConstraintViolation>
+	<ConstraintViolation>
+		<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept' is recommended</Message>
+	</ConstraintViolation>
+	<ConstraintViolation>
+		<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocab' is recommended</Message>
+	</ConstraintViolation>
+	<ConstraintViolation>
+		<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept' is recommended</Message>
+	</ConstraintViolation>
+	<ConstraintViolation>
+		<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept/@vocab' is recommended</Message>
+	</ConstraintViolation>
+	<ConstraintViolation>
+		<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept' is recommended</Message>
+	</ConstraintViolation>
+	<ConstraintViolation>
+		<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept/@vocab' is recommended</Message>
+	</ConstraintViolation>
+	<ConstraintViolation>
+		<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept' is recommended</Message>
+	</ConstraintViolation>
+	<ConstraintViolation>
+		<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept/@vocab' is recommended</Message>
+	</ConstraintViolation>
+	<ConstraintViolation>
+		<Message>'/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName' is recommended</Message>
+	</ConstraintViolation>
+	<ConstraintViolation>
+		<Message>'/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName/@xml:lang' is recommended</Message>
+	</ConstraintViolation>
 </ValidationReport>

--- a/src/test/resources/eu.cessda.cmv.core.mediatype.validationreport.ValidationReportTest/jackson.json
+++ b/src/test/resources/eu.cessda.cmv.core.mediatype.validationreport.ValidationReportTest/jackson.json
@@ -1,49 +1,64 @@
 {
-  "DocumentUri" : "urn:uuid:00000000-0000-0000-0000-000000000000",
-  "ConstraintViolation" : [ {
-    "message" : "'/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocab' is recommended",
-    "LocationInfo" : null
-  }, {
-    "message" : "'/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocabURI' is recommended",
-    "LocationInfo" : null
-  }, {
-    "message" : "'./@event' is mandatory in /codeBook/stdyDscr/stdyInfo/sumDscr/collDate",
-    "LocationInfo" : {
-      "lineNumber" : 74,
-      "columnNumber" : 33
-    }
-  }, {
-    "message" : "'/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@abbr' is recommended",
-    "LocationInfo" : null
-  }, {
-    "message" : "'/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept' is recommended",
-    "LocationInfo" : null
-  }, {
-    "message" : "'/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab' is recommended",
-    "LocationInfo" : null
-  }, {
-    "message" : "'/codeBook/stdyDscr/method/dataColl/timeMeth/concept' is recommended",
-    "LocationInfo" : null
-  }, {
-    "message" : "'/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocab' is recommended",
-    "LocationInfo" : null
-  }, {
-    "message" : "'/codeBook/stdyDscr/method/dataColl/sampProc/concept' is recommended",
-    "LocationInfo" : null
-  }, {
-    "message" : "'/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocab' is recommended",
-    "LocationInfo" : null
-  }, {
-    "message" : "'/codeBook/stdyDscr/method/dataColl/collMode/concept' is recommended",
-    "LocationInfo" : null
-  }, {
-    "message" : "'/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocab' is recommended",
-    "LocationInfo" : null
-  }, {
-    "message" : "'/codeBook/fileDscr/fileTxt/fileName' is recommended",
-    "LocationInfo" : null
-  }, {
-    "message" : "'/codeBook/fileDscr/fileTxt/fileName/@xml:lang' is recommended",
-    "LocationInfo" : null
-  } ]
+	"DocumentUri": "urn:uuid:00000000-0000-0000-0000-000000000000",
+	"ConstraintViolation": [
+		{
+			"message": "'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocab' is recommended",
+			"LocationInfo": null
+		},
+		{
+			"message": "'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocabURI' is recommended",
+			"LocationInfo": null
+		},
+		{
+			"message": "'./@event' is mandatory in /ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate",
+			"LocationInfo": {
+				"lineNumber": 74,
+				"columnNumber": 33
+			}
+		},
+		{
+			"message": "'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation/@abbr' is recommended",
+			"LocationInfo": null
+		},
+		{
+			"message": "'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept' is recommended",
+			"LocationInfo": null
+		},
+		{
+			"message": "'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocab' is recommended",
+			"LocationInfo": null
+		},
+		{
+			"message": "'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept' is recommended",
+			"LocationInfo": null
+		},
+		{
+			"message": "'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept/@vocab' is recommended",
+			"LocationInfo": null
+		},
+		{
+			"message": "'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept' is recommended",
+			"LocationInfo": null
+		},
+		{
+			"message": "'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept/@vocab' is recommended",
+			"LocationInfo": null
+		},
+		{
+			"message": "'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept' is recommended",
+			"LocationInfo": null
+		},
+		{
+			"message": "'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept/@vocab' is recommended",
+			"LocationInfo": null
+		},
+		{
+			"message": "'/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName' is recommended",
+			"LocationInfo": null
+		},
+		{
+			"message": "'/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName/@xml:lang' is recommended",
+			"LocationInfo": null
+		}
+	]
 }

--- a/src/test/resources/eu.cessda.cmv.core.mediatype.validationreport.ValidationReportTest/jackson.xml
+++ b/src/test/resources/eu.cessda.cmv.core.mediatype.validationreport.ValidationReportTest/jackson.xml
@@ -1,64 +1,64 @@
 <ValidationReport>
-  <DocumentUri>urn:uuid:00000000-0000-0000-0000-000000000000</DocumentUri>
-  <ConstraintViolation>
-    <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocab' is recommended</Message>
-      <LocationInfo/>
-    </ConstraintViolation>
-    <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocabURI' is recommended</Message>
-      <LocationInfo/>
-    </ConstraintViolation>
-    <ConstraintViolation>
-      <Message>'./@event' is mandatory in /codeBook/stdyDscr/stdyInfo/sumDscr/collDate</Message>
-      <LocationInfo>
-        <LineNumber>74</LineNumber>
-        <ColumnNumber>33</ColumnNumber>
-      </LocationInfo>
-    </ConstraintViolation>
-    <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@abbr' is recommended</Message>
-      <LocationInfo/>
-    </ConstraintViolation>
-    <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept' is recommended</Message>
-      <LocationInfo/>
-    </ConstraintViolation>
-    <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab' is recommended</Message>
-      <LocationInfo/>
-    </ConstraintViolation>
-    <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/method/dataColl/timeMeth/concept' is recommended</Message>
-      <LocationInfo/>
-    </ConstraintViolation>
-    <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocab' is recommended</Message>
-      <LocationInfo/>
-    </ConstraintViolation>
-    <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/method/dataColl/sampProc/concept' is recommended</Message>
-      <LocationInfo/>
-    </ConstraintViolation>
-    <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocab' is recommended</Message>
-      <LocationInfo/>
-    </ConstraintViolation>
-    <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/method/dataColl/collMode/concept' is recommended</Message>
-      <LocationInfo/>
-    </ConstraintViolation>
-    <ConstraintViolation>
-      <Message>'/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocab' is recommended</Message>
-      <LocationInfo/>
-    </ConstraintViolation>
-    <ConstraintViolation>
-      <Message>'/codeBook/fileDscr/fileTxt/fileName' is recommended</Message>
-      <LocationInfo/>
-    </ConstraintViolation>
-    <ConstraintViolation>
-      <Message>'/codeBook/fileDscr/fileTxt/fileName/@xml:lang' is recommended</Message>
-      <LocationInfo/>
-    </ConstraintViolation>
-  </ConstraintViolation>
+	<DocumentUri>urn:uuid:00000000-0000-0000-0000-000000000000</DocumentUri>
+	<ConstraintViolation>
+		<ConstraintViolation>
+			<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocab' is recommended</Message>
+			<LocationInfo/>
+		</ConstraintViolation>
+		<ConstraintViolation>
+			<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocabURI' is recommended</Message>
+			<LocationInfo/>
+		</ConstraintViolation>
+		<ConstraintViolation>
+			<Message>'./@event' is mandatory in /ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate</Message>
+			<LocationInfo>
+				<LineNumber>74</LineNumber>
+				<ColumnNumber>33</ColumnNumber>
+			</LocationInfo>
+		</ConstraintViolation>
+		<ConstraintViolation>
+			<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation/@abbr' is recommended</Message>
+			<LocationInfo/>
+		</ConstraintViolation>
+		<ConstraintViolation>
+			<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept' is recommended</Message>
+			<LocationInfo/>
+		</ConstraintViolation>
+		<ConstraintViolation>
+			<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocab' is recommended</Message>
+			<LocationInfo/>
+		</ConstraintViolation>
+		<ConstraintViolation>
+			<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept' is recommended</Message>
+			<LocationInfo/>
+		</ConstraintViolation>
+		<ConstraintViolation>
+			<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept/@vocab' is recommended</Message>
+			<LocationInfo/>
+		</ConstraintViolation>
+		<ConstraintViolation>
+			<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept' is recommended</Message>
+			<LocationInfo/>
+		</ConstraintViolation>
+		<ConstraintViolation>
+			<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept/@vocab' is recommended</Message>
+			<LocationInfo/>
+		</ConstraintViolation>
+		<ConstraintViolation>
+			<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept' is recommended</Message>
+			<LocationInfo/>
+		</ConstraintViolation>
+		<ConstraintViolation>
+			<Message>'/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept/@vocab' is recommended</Message>
+			<LocationInfo/>
+		</ConstraintViolation>
+		<ConstraintViolation>
+			<Message>'/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName' is recommended</Message>
+			<LocationInfo/>
+		</ConstraintViolation>
+		<ConstraintViolation>
+			<Message>'/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName/@xml:lang' is recommended</Message>
+			<LocationInfo/>
+		</ConstraintViolation>
+	</ConstraintViolation>
 </ValidationReport>

--- a/src/test/resources/profiles/cdc25_profile_cmv.xml
+++ b/src/test/resources/profiles/cdc25_profile_cmv.xml
@@ -1,608 +1,619 @@
-<Profile xmlns="cmv:profile:v0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="cmv:profile:v0 https://raw.githubusercontent.com/cessda/cessda.cmv.core/stable/schema/profile-v0.1.xsd">
+<Profile xmlns="cmv:profile:v0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="cmv:profile:v0 https://raw.githubusercontent.com/cessda/cessda.cmv.core/stable/schema/profile-v0.2.xsd">
 	<Name>CESSDA DATA CATALOGUE (CDC) DDI2.5 PROFILE</Name>
+	<Version>1.0.4</Version>
+	<PrefixMaps>
+		<PrefixMap>
+			<Prefix>ddi</Prefix>
+			<Namespace>ddi:codebook:2_5</Namespace>
+		</PrefixMap>
+		<PrefixMap>
+			<Prefix>xsi</Prefix>
+			<Namespace>http://www.w3.org/2001/XMLSchema-instance</Namespace>
+		</PrefixMap>
+	</PrefixMaps>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/@xml:lang</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/@xml:lang</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/@xml:lang</LocationPath>
 	</RecommendedNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/@xsi:schemaLocation</LocationPath>
+		<LocationPath>/ddi:codeBook/@xsi:schemaLocation</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/@xsi:schemaLocation</LocationPath>
+		<LocationPath>/ddi:codeBook/@xsi:schemaLocation</LocationPath>
 	</PredicatelessXPathConstraint>
 	<MandatoryNodeConstraint>
-		<LocationPath>/codeBook/@xsi:schemaLocation</LocationPath>
+		<LocationPath>/ddi:codeBook/@xsi:schemaLocation</LocationPath>
 	</MandatoryNodeConstraint>
 	<FixedValueNodeConstraint>
-		<LocationPath>/codeBook/@xsi:schemaLocation</LocationPath>
+		<LocationPath>/ddi:codeBook/@xsi:schemaLocation</LocationPath>
 		<FixedValue>ddi:codebook:2_5 http://www.ddialliance.org/Specification/DDI-Codebook/2.5/XMLSchema/codebook.xsd</FixedValue>
 	</FixedValueNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/docDscr/citation/titlStmt/titl</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:docDscr/ddi:citation/ddi:titlStmt/ddi:titl</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/docDscr/citation/titlStmt/titl</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:docDscr/ddi:citation/ddi:titlStmt/ddi:titl</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/docDscr/citation/titlStmt/titl</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:docDscr/ddi:citation/ddi:titlStmt/ddi:titl</LocationPath>
 	</OptionalNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/docDscr/citation/titlStmt/titl/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:docDscr/ddi:citation/ddi:titlStmt/ddi:titl/@xml:lang</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/docDscr/citation/titlStmt/titl/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:docDscr/ddi:citation/ddi:titlStmt/ddi:titl/@xml:lang</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/docDscr/citation/titlStmt/titl/@xml:lang</LocationPath>
-	</OptionalNodeConstraint>
-	<MandatoryNodeIfParentPresentConstraint>
-		<LocationPath>/codeBook/docDscr/citation/titlStmt/titl/@xml:lang</LocationPath>
-	</MandatoryNodeIfParentPresentConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/titl</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/titl</LocationPath>
-	</PredicatelessXPathConstraint>
-	<MandatoryNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/titl</LocationPath>
-	</MandatoryNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/titl/@xml:lang</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/titl/@xml:lang</LocationPath>
-	</PredicatelessXPathConstraint>
-	<MandatoryNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/titl/@xml:lang</LocationPath>
-	</MandatoryNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/parTitl</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/parTitl</LocationPath>
-	</PredicatelessXPathConstraint>
-	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/parTitl</LocationPath>
-	</OptionalNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/parTitl/@xml:lang</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/parTitl/@xml:lang</LocationPath>
-	</PredicatelessXPathConstraint>
-	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/parTitl/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:docDscr/ddi:citation/ddi:titlStmt/ddi:titl/@xml:lang</LocationPath>
 	</OptionalNodeConstraint>
 	<MandatoryNodeIfParentPresentConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/parTitl/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:docDscr/ddi:citation/ddi:titlStmt/ddi:titl/@xml:lang</LocationPath>
 	</MandatoryNodeIfParentPresentConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/IDNo</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/IDNo</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl</LocationPath>
 	</PredicatelessXPathConstraint>
 	<MandatoryNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/IDNo</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl</LocationPath>
 	</MandatoryNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/IDNo/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl/@xml:lang</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/IDNo/@xml:lang</LocationPath>
-	</PredicatelessXPathConstraint>
-	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/IDNo/@xml:lang</LocationPath>
-	</RecommendedNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/IDNo/@agency</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/IDNo/@agency</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl/@xml:lang</LocationPath>
 	</PredicatelessXPathConstraint>
 	<MandatoryNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/titlStmt/IDNo/@agency</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:titl/@xml:lang</LocationPath>
 	</MandatoryNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/holdings/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:parTitl</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/holdings/@xml:lang</LocationPath>
-	</PredicatelessXPathConstraint>
-	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/holdings/@xml:lang</LocationPath>
-	</RecommendedNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/holdings/@URI</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/holdings/@URI</LocationPath>
-	</PredicatelessXPathConstraint>
-	<MandatoryNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/holdings/@URI</LocationPath>
-	</MandatoryNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/rspStmt/AuthEnty</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/rspStmt/AuthEnty</LocationPath>
-	</PredicatelessXPathConstraint>
-	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/rspStmt/AuthEnty</LocationPath>
-	</RecommendedNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/rspStmt/AuthEnty/@xml:lang</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/rspStmt/AuthEnty/@xml:lang</LocationPath>
-	</PredicatelessXPathConstraint>
-	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/rspStmt/AuthEnty/@xml:lang</LocationPath>
-	</RecommendedNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/rspStmt/AuthEnty/@affiliation</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/rspStmt/AuthEnty/@affiliation</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:parTitl</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/rspStmt/AuthEnty/@affiliation</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:parTitl</LocationPath>
 	</OptionalNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distrbtr</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:parTitl/@xml:lang</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distrbtr</LocationPath>
-	</PredicatelessXPathConstraint>
-	<MandatoryNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distrbtr</LocationPath>
-	</MandatoryNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distrbtr/@xml:lang</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distrbtr/@xml:lang</LocationPath>
-	</PredicatelessXPathConstraint>
-	<MandatoryNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distrbtr/@xml:lang</LocationPath>
-	</MandatoryNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distrbtr/@abbr</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distrbtr/@abbr</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:parTitl/@xml:lang</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distrbtr/@abbr</LocationPath>
-	</OptionalNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distDate</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distDate</LocationPath>
-	</PredicatelessXPathConstraint>
-	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distDate</LocationPath>
-	</OptionalNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distDate/@date</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distDate/@date</LocationPath>
-	</PredicatelessXPathConstraint>
-	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distDate/@date</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:parTitl/@xml:lang</LocationPath>
 	</OptionalNodeConstraint>
 	<MandatoryNodeIfParentPresentConstraint>
-		<LocationPath>/codeBook/stdyDscr/citation/distStmt/distDate/@date</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:parTitl/@xml:lang</LocationPath>
 	</MandatoryNodeIfParentPresentConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/keyword</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/keyword</LocationPath>
-	</PredicatelessXPathConstraint>
-	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/keyword</LocationPath>
-	</RecommendedNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/keyword/@xml:lang</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/keyword/@xml:lang</LocationPath>
-	</PredicatelessXPathConstraint>
-	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/keyword/@xml:lang</LocationPath>
-	</OptionalNodeConstraint>
-	<MandatoryNodeIfParentPresentConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/keyword/@xml:lang</LocationPath>
-	</MandatoryNodeIfParentPresentConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/keyword/@vocab</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/keyword/@vocab</LocationPath>
-	</PredicatelessXPathConstraint>
-	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/keyword/@vocab</LocationPath>
-	</RecommendedNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/keyword/@vocabURI</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/keyword/@vocabURI</LocationPath>
-	</PredicatelessXPathConstraint>
-	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/keyword/@vocabURI</LocationPath>
-	</OptionalNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/topcClas</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/topcClas</LocationPath>
-	</PredicatelessXPathConstraint>
-	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/topcClas</LocationPath>
-	</RecommendedNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/topcClas/@xml:lang</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/topcClas/@xml:lang</LocationPath>
-	</PredicatelessXPathConstraint>
-	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/topcClas/@xml:lang</LocationPath>
-	</OptionalNodeConstraint>
-	<MandatoryNodeIfParentPresentConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/topcClas/@xml:lang</LocationPath>
-	</MandatoryNodeIfParentPresentConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocab</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocab</LocationPath>
-	</PredicatelessXPathConstraint>
-	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocab</LocationPath>
-	</RecommendedNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocabURI</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocabURI</LocationPath>
-	</PredicatelessXPathConstraint>
-	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/subject/topcClas/@vocabURI</LocationPath>
-	</RecommendedNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/abstract</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/abstract</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo</LocationPath>
 	</PredicatelessXPathConstraint>
 	<MandatoryNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/abstract</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo</LocationPath>
 	</MandatoryNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/abstract/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo/@xml:lang</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/abstract/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo/@xml:lang</LocationPath>
+	</PredicatelessXPathConstraint>
+	<RecommendedNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo/@xml:lang</LocationPath>
+	</RecommendedNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo/@agency</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo/@agency</LocationPath>
 	</PredicatelessXPathConstraint>
 	<MandatoryNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/abstract/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:titlStmt/ddi:IDNo/@agency</LocationPath>
 	</MandatoryNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/collDate</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:holdings/@xml:lang</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/collDate</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:holdings/@xml:lang</LocationPath>
+	</PredicatelessXPathConstraint>
+	<RecommendedNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:holdings/@xml:lang</LocationPath>
+	</RecommendedNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:holdings/@URI</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:holdings/@URI</LocationPath>
+	</PredicatelessXPathConstraint>
+	<MandatoryNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:holdings/@URI</LocationPath>
+	</MandatoryNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty</LocationPath>
+	</PredicatelessXPathConstraint>
+	<RecommendedNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty</LocationPath>
+	</RecommendedNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty/@xml:lang</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty/@xml:lang</LocationPath>
+	</PredicatelessXPathConstraint>
+	<RecommendedNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty/@xml:lang</LocationPath>
+	</RecommendedNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty/@affiliation</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty/@affiliation</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/collDate</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:rspStmt/ddi:AuthEnty/@affiliation</LocationPath>
 	</OptionalNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@event</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@event</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr</LocationPath>
+	</PredicatelessXPathConstraint>
+	<MandatoryNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr</LocationPath>
+	</MandatoryNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr/@xml:lang</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr/@xml:lang</LocationPath>
+	</PredicatelessXPathConstraint>
+	<MandatoryNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr/@xml:lang</LocationPath>
+	</MandatoryNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr/@abbr</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr/@abbr</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@event</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distrbtr/@abbr</LocationPath>
+	</OptionalNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distDate</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distDate</LocationPath>
+	</PredicatelessXPathConstraint>
+	<OptionalNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distDate</LocationPath>
+	</OptionalNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distDate/@date</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distDate/@date</LocationPath>
+	</PredicatelessXPathConstraint>
+	<OptionalNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distDate/@date</LocationPath>
 	</OptionalNodeConstraint>
 	<MandatoryNodeIfParentPresentConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@event</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:citation/ddi:distStmt/ddi:distDate/@date</LocationPath>
 	</MandatoryNodeIfParentPresentConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@date</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@date</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/collDate/@date</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword</LocationPath>
 	</RecommendedNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/nation</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@xml:lang</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/nation</LocationPath>
-	</PredicatelessXPathConstraint>
-	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/nation</LocationPath>
-	</RecommendedNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@xml:lang</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@xml:lang</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@xml:lang</LocationPath>
 	</OptionalNodeConstraint>
 	<MandatoryNodeIfParentPresentConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@xml:lang</LocationPath>
 	</MandatoryNodeIfParentPresentConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@abbr</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@vocab</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@abbr</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@vocab</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/nation/@abbr</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@vocab</LocationPath>
 	</RecommendedNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@vocabURI</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit</LocationPath>
-	</PredicatelessXPathConstraint>
-	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit</LocationPath>
-	</RecommendedNodeConstraint>
-	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/@xml:lang</LocationPath>
-	</CompilableXPathConstraint>
-	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@vocabURI</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:keyword/@vocabURI</LocationPath>
 	</OptionalNodeConstraint>
-	<MandatoryNodeIfParentPresentConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/@xml:lang</LocationPath>
-	</MandatoryNodeIfParentPresentConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas</LocationPath>
 	</RecommendedNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@xml:lang</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@xml:lang</LocationPath>
+	</PredicatelessXPathConstraint>
+	<OptionalNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@xml:lang</LocationPath>
+	</OptionalNodeConstraint>
+	<MandatoryNodeIfParentPresentConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@xml:lang</LocationPath>
+	</MandatoryNodeIfParentPresentConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocab</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocab</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocab</LocationPath>
+	</RecommendedNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocabURI</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocabURI</LocationPath>
+	</PredicatelessXPathConstraint>
+	<RecommendedNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:subject/ddi:topcClas/@vocabURI</LocationPath>
+	</RecommendedNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:abstract</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:abstract</LocationPath>
+	</PredicatelessXPathConstraint>
+	<MandatoryNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:abstract</LocationPath>
+	</MandatoryNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:abstract/@xml:lang</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:abstract/@xml:lang</LocationPath>
+	</PredicatelessXPathConstraint>
+	<MandatoryNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:abstract/@xml:lang</LocationPath>
+	</MandatoryNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate</LocationPath>
+	</PredicatelessXPathConstraint>
+	<OptionalNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate</LocationPath>
+	</OptionalNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate/@event</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate/@event</LocationPath>
+	</PredicatelessXPathConstraint>
+	<OptionalNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate/@event</LocationPath>
+	</OptionalNodeConstraint>
+	<MandatoryNodeIfParentPresentConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate/@event</LocationPath>
+	</MandatoryNodeIfParentPresentConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate/@date</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate/@date</LocationPath>
+	</PredicatelessXPathConstraint>
+	<RecommendedNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:collDate/@date</LocationPath>
+	</RecommendedNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation</LocationPath>
+	</PredicatelessXPathConstraint>
+	<RecommendedNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation</LocationPath>
+	</RecommendedNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation/@xml:lang</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation/@xml:lang</LocationPath>
+	</PredicatelessXPathConstraint>
+	<OptionalNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation/@xml:lang</LocationPath>
+	</OptionalNodeConstraint>
+	<MandatoryNodeIfParentPresentConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation/@xml:lang</LocationPath>
+	</MandatoryNodeIfParentPresentConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation/@abbr</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation/@abbr</LocationPath>
+	</PredicatelessXPathConstraint>
+	<RecommendedNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:nation/@abbr</LocationPath>
+	</RecommendedNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit</LocationPath>
+	</PredicatelessXPathConstraint>
+	<RecommendedNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit</LocationPath>
+	</RecommendedNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/@xml:lang</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/@xml:lang</LocationPath>
+	</PredicatelessXPathConstraint>
+	<OptionalNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/@xml:lang</LocationPath>
+	</OptionalNodeConstraint>
+	<MandatoryNodeIfParentPresentConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/@xml:lang</LocationPath>
+	</MandatoryNodeIfParentPresentConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept</LocationPath>
+	</PredicatelessXPathConstraint>
+	<RecommendedNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept</LocationPath>
+	</RecommendedNodeConstraint>
+	<CompilableXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocab</LocationPath>
+	</CompilableXPathConstraint>
+	<PredicatelessXPathConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocab</LocationPath>
+	</PredicatelessXPathConstraint>
+	<RecommendedNodeConstraint>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocab</LocationPath>
 	</RecommendedNodeConstraint>
 	<FixedValueNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocab</LocationPath>
 		<FixedValue>DDI Analysis Unit</FixedValue>
 	</FixedValueNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocabURI</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocabURI</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocabURI</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocabURI</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/stdyInfo/sumDscr/anlyUnit/concept/@vocabURI</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:stdyInfo/ddi:sumDscr/ddi:anlyUnit/ddi:concept/@vocabURI</LocationPath>
 	</OptionalNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth</LocationPath>
 	</RecommendedNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/@xml:lang</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/@xml:lang</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/@xml:lang</LocationPath>
 	</OptionalNodeConstraint>
 	<MandatoryNodeIfParentPresentConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/@xml:lang</LocationPath>
 	</MandatoryNodeIfParentPresentConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth/concept</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth/concept</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth/concept</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept</LocationPath>
 	</RecommendedNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept/@vocab</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept/@vocab</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept/@vocab</LocationPath>
 	</RecommendedNodeConstraint>
 	<FixedValueNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept/@vocab</LocationPath>
 		<FixedValue>DDI Time Method</FixedValue>
 	</FixedValueNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocabURI</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept/@vocabURI</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocabURI</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept/@vocabURI</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/timeMeth/concept/@vocabURI</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:timeMeth/ddi:concept/@vocabURI</LocationPath>
 	</OptionalNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc</LocationPath>
 	</OptionalNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/@xml:lang</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/@xml:lang</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/@xml:lang</LocationPath>
 	</OptionalNodeConstraint>
 	<MandatoryNodeIfParentPresentConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/@xml:lang</LocationPath>
 	</MandatoryNodeIfParentPresentConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc/concept</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc/concept</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc/concept</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept</LocationPath>
 	</RecommendedNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept/@vocab</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept/@vocab</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept/@vocab</LocationPath>
 	</RecommendedNodeConstraint>
 	<FixedValueNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept/@vocab</LocationPath>
 		<FixedValue>DDI Sampling Procedure</FixedValue>
 	</FixedValueNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocabURI</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept/@vocabURI</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocabURI</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept/@vocabURI</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/sampProc/concept/@vocabURI</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:sampProc/ddi:concept/@vocabURI</LocationPath>
 	</OptionalNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode</LocationPath>
 	</RecommendedNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/@xml:lang</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/@xml:lang</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/@xml:lang</LocationPath>
 	</OptionalNodeConstraint>
 	<MandatoryNodeIfParentPresentConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/@xml:lang</LocationPath>
 	</MandatoryNodeIfParentPresentConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode/concept</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode/concept</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode/concept</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept</LocationPath>
 	</RecommendedNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept/@vocab</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept/@vocab</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept/@vocab</LocationPath>
 	</RecommendedNodeConstraint>
 	<FixedValueNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocab</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept/@vocab</LocationPath>
 		<FixedValue>DDI Mode of Collection</FixedValue>
 	</FixedValueNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocabURI</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept/@vocabURI</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocabURI</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept/@vocabURI</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/method/dataColl/collMode/concept/@vocabURI</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:method/ddi:dataColl/ddi:collMode/ddi:concept/@vocabURI</LocationPath>
 	</OptionalNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/dataAccs/useStmt/restrctn</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:restrctn</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/dataAccs/useStmt/restrctn</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:restrctn</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/dataAccs/useStmt/restrctn</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:restrctn</LocationPath>
 	</RecommendedNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/dataAccs/useStmt/restrctn/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:restrctn/@xml:lang</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/stdyDscr/dataAccs/useStmt/restrctn/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:restrctn/@xml:lang</LocationPath>
 	</PredicatelessXPathConstraint>
 	<OptionalNodeConstraint>
-		<LocationPath>/codeBook/stdyDscr/dataAccs/useStmt/restrctn/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:restrctn/@xml:lang</LocationPath>
 	</OptionalNodeConstraint>
 	<MandatoryNodeIfParentPresentConstraint>
-		<LocationPath>/codeBook/stdyDscr/dataAccs/useStmt/restrctn/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:stdyDscr/ddi:dataAccs/ddi:useStmt/ddi:restrctn/@xml:lang</LocationPath>
 	</MandatoryNodeIfParentPresentConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/fileDscr/fileTxt/fileName</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/fileDscr/fileTxt/fileName</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/fileDscr/fileTxt/fileName</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName</LocationPath>
 	</RecommendedNodeConstraint>
 	<CompilableXPathConstraint>
-		<LocationPath>/codeBook/fileDscr/fileTxt/fileName/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName/@xml:lang</LocationPath>
 	</CompilableXPathConstraint>
 	<PredicatelessXPathConstraint>
-		<LocationPath>/codeBook/fileDscr/fileTxt/fileName/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName/@xml:lang</LocationPath>
 	</PredicatelessXPathConstraint>
 	<RecommendedNodeConstraint>
-		<LocationPath>/codeBook/fileDscr/fileTxt/fileName/@xml:lang</LocationPath>
+		<LocationPath>/ddi:codeBook/ddi:fileDscr/ddi:fileTxt/ddi:fileName/@xml:lang</LocationPath>
 	</RecommendedNodeConstraint>
 </Profile>


### PR DESCRIPTION
This PR implements support for correctly parsing namespaces within XML documents.

This PR changes the behavior in the parsing of XPaths. Before prefixes were not treated separately from the rest of the element's name. With this PR prefixes are mapped onto namespaces using the mappings defined in the profile.

Prefix-to-namespace mapping is extracted from the DDI profile using `XMLPrefixMap` elements.

```xml
<pr:DDIProfile xmlns:pr="ddi:ddiprofile:3_2">
...
    <pr:XMLPrefixMap>
        <pr:XMLPrefix>ddi</pr:XMLPrefix>
        <pr:XMLNamespace>ddi:codebook:2_5</pr:XMLNamespace>
    </pr:XMLPrefixMap>
...
</pr:DDIProfile>
```

Referencing elements in XPaths that don't have a namespace prefix (e.g. `/element`) always refers to the the empty namespace "". Attempting to map such a prefix will have no effect. This is a limitation of the XPath 1.0 specification. 

The JAXBProfile serialisations have been updated.

```xml
<Profile xmlns="cmv:profile:v0">
...
	<PrefixMaps>
		<PrefixMap>
			<Prefix>ddi</Prefix>
			<Namespace>ddi:codebook:2_5</Namespace>
		</PrefixMap>
		<PrefixMap>
			<Prefix>xsi</Prefix>
			<Namespace>http://www.w3.org/2001/XMLSchema-instance</Namespace>
		</PrefixMap>
	</PrefixMaps>
...
</Profile>
```

See https://github.com/cessda/cessda.metadata.profiles/issues/177 for how this PR will affect metadata profiles.

This closes #111